### PR TITLE
fix: add security headers and rel=noopener to external links

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -466,8 +466,8 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
   <button class="mob-close" onclick="closeMob()">✕</button>
   <a href="#" onclick="showHome();closeMob();return false">Home</a>
   <a href="#" onclick="showPortfolio();closeMob();return false">Portfolio</a>
-  <a href="https://www.artstation.com/giovannilauffer" target="_blank" onclick="closeMob()">ArtStation</a>
-  <a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank" onclick="closeMob()">LinkedIn</a>
+  <a href="https://www.artstation.com/giovannilauffer" target="_blank" rel="noopener noreferrer" onclick="closeMob()">ArtStation</a>
+  <a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank" rel="noopener noreferrer" onclick="closeMob()">LinkedIn</a>
   <a href="mailto:giovanni@giovannilauffer.com" class="mob-cta">Hire Me</a>
 </div>
 
@@ -479,8 +479,8 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
   <ul class="nlinks">
     <li><a href="#" onclick="showHome();return false">Home</a></li>
     <li><a href="#" onclick="showPortfolio();return false">Portfolio</a></li>
-    <li><a href="https://www.artstation.com/giovannilauffer" target="_blank">ArtStation</a></li>
-    <li><a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank">LinkedIn</a></li>
+    <li><a href="https://www.artstation.com/giovannilauffer" target="_blank" rel="noopener noreferrer">ArtStation</a></li>
+    <li><a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
   </ul>
   <a href="mailto:giovanni@giovannilauffer.com" class="ncta">Hire Me</a>
   <button class="musicbtn" id="musicbtn" onclick="toggleMusic()" title="Toggle music" aria-label="Toggle background music">
@@ -625,7 +625,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
     <div class="wsec">Work Experience</div>
     <div class="witems">
 
-      <a class="wi wi-link" href="https://www.timesplittersrewind.com/" target="_blank" rel="noopener">
+      <a class="wi wi-link" href="https://www.timesplittersrewind.com/" target="_blank" rel="noopener noreferrer">
         <div class="wlogo"><img src="/wp-content/uploads/2024/07/Cinder.webp" alt="Cinder Interactive"></div>
         <div class="wdiv"></div>
         <div class="winfo">
@@ -642,7 +642,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
         </div>
       </a>
 
-      <a class="wi wi-link" href="https://www.lukkien.com/" target="_blank" rel="noopener">
+      <a class="wi wi-link" href="https://www.lukkien.com/" target="_blank" rel="noopener noreferrer">
         <div class="wlogo"><img src="/wp-content/uploads/2024/07/LUKKIEN-1024x221.webp" alt="Lukkien"></div>
         <div class="wdiv"></div>
         <div class="winfo">
@@ -664,7 +664,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
     <div class="wsec" style="margin-top:3rem">Education</div>
     <div class="witems">
 
-      <a class="wi wi-link" href="https://www.saxion.nl/en" target="_blank" rel="noopener">
+      <a class="wi wi-link" href="https://www.saxion.nl/en" target="_blank" rel="noopener noreferrer">
         <div class="wlogo"><img src="/wp-content/uploads/2024/07/lg_saxion_rgb.webp" alt="Saxion"></div>
         <div class="wdiv"></div>
         <div class="winfo">
@@ -674,7 +674,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
         </div>
       </a>
 
-      <a class="wi wi-link" href="https://www.beyondextent.com/" target="_blank" rel="noopener">
+      <a class="wi wi-link" href="https://www.beyondextent.com/" target="_blank" rel="noopener noreferrer">
         <div class="wlogo"><img src="/wp-content/uploads/2025/11/BeyondExtent_Logo_White_Monotone-150x150.webp" alt="Beyond Extent"></div>
         <div class="wdiv"></div>
         <div class="winfo">
@@ -684,7 +684,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
         </div>
       </a>
 
-      <a class="wi wi-link" href="https://www.isc.cw/" target="_blank" rel="noopener">
+      <a class="wi wi-link" href="https://www.isc.cw/" target="_blank" rel="noopener noreferrer">
         <div class="wlogo"><img src="/wp-content/uploads/2024/07/ISC.webp" alt="ISC"></div>
         <div class="wdiv"></div>
         <div class="winfo">
@@ -715,7 +715,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
   <div class="rstrip">
     <div class="wsec">Industry Recommendations</div>
     <div class="recgrid">
-      <a class="rc" href="https://cameronwgames.com/" target="_blank" rel="noopener">
+      <a class="rc" href="https://cameronwgames.com/" target="_blank" rel="noopener noreferrer">
         <div class="rq">"Giovanni has a striking mindset of 'what's next' and was always extremely enthusiastic in providing high quality assets. We put him on the highest quality hero assets, trusting him with some of the most commonly viewed props throughout the game. I highly recommend Giovanni — he'd do great in any studio."</div>
         <div class="rp">
           <img src="/wp-content/uploads/2025/03/cam.webp" alt="Cameron Williams">
@@ -725,7 +725,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
           </div>
         </div>
       </a>
-      <a class="rc" href="https://www.willemkranendonk.com/" target="_blank" rel="noopener">
+      <a class="rc" href="https://www.willemkranendonk.com/" target="_blank" rel="noopener noreferrer">
         <div class="rq">"Giovanni is an incredible person as well as a passionate developer. He is an adaptable artist who works well with others and strives to be better every single day. You will not only get a strong and passionate artist but you will also get a good person."</div>
         <div class="rp">
           <img src="/wp-content/uploads/2025/03/willem.webp" alt="Willem Kranendonk">
@@ -735,7 +735,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
           </div>
         </div>
       </a>
-      <a class="rc" href="https://www.artstation.com/samueltfreeman" target="_blank" rel="noopener">
+      <a class="rc" href="https://www.artstation.com/samueltfreeman" target="_blank" rel="noopener noreferrer">
         <div class="rq">"Giovanni demonstrated a strong work ethic and a remarkable ability to handle critique effectively. His dedication, receptive attitude, and effective collaboration make him a valuable asset to any creative endeavor."</div>
         <div class="rp">
           <img src="/wp-content/uploads/2024/08/Samuel-Freeman.jpg" alt="Samuel Freeman">
@@ -745,7 +745,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
           </div>
         </div>
       </a>
-      <a class="rc" href="https://www.rituals.com/" target="_blank" rel="noopener">
+      <a class="rc" href="https://www.rituals.com/" target="_blank" rel="noopener noreferrer">
         <div class="rq">"Giovanni is a great co-worker with a strong drive to learn. He likes to perform and get things done."</div>
         <div class="rp">
           <img src="/wp-content/uploads/2024/08/rutgher-e1684957341766.jpg" alt="Rutgher Jousma">
@@ -817,8 +817,8 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 <div class="hire" id="hire">
   <div class="htxt"><span class="hdot"></span><strong>Available for work</strong>&nbsp;— Senior 3D Artist roles · Game studios · Remote or on-site · Ede, NL</div>
   <div class="hact">
-    <a href="https://www.artstation.com/giovannilauffer" target="_blank" class="hl hls">ArtStation</a>
-    <a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank" class="hl hls">LinkedIn</a>
+    <a href="https://www.artstation.com/giovannilauffer" target="_blank" rel="noopener noreferrer" class="hl hls">ArtStation</a>
+    <a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank" rel="noopener noreferrer" class="hl hls">LinkedIn</a>
     <a href="mailto:giovanni@giovannilauffer.com" class="hl hlp">Contact Me →</a>
   </div>
 </div>
@@ -1274,11 +1274,11 @@ const POSTS={
     tagline:'Environment Art · Beyond Extent · Team Project',
     tags:[['Environment Art','h'],['Beyond Extent','h'],['Hero Prop',''],['Skulls',''],['Voodoo Decals',''],['UE5','']],
     desc:`<p>I recently took part in the Witches' Den team challenge with Beyond Extent. Over the course of five weeks, our team of five artists planned, developed, and produced a full set of 3D game-ready assets to bring this environment to life.</p><p>Working with the team was an incredibly rewarding experience, and I'm really proud of what we achieved together. My contributions included creating a hero prop (a boat), sculpting and modelling skull assets, high poly to low poly baking, producing Voodoo veve alphas for decal texturing, and collaborating on the overall level design from the initial blockout all the way to the final result.</p><p>Be sure to check out the amazing work from the rest of the team:<br>
-      <a href="https://www.artstation.com/jackshergold" target="_blank" style="color:var(--acc)">Jack Shergold</a> ·
-      <a href="https://www.artstation.com/joebates1" target="_blank" style="color:var(--acc)">Joe Bates</a> ·
-      <a href="https://www.artstation.com/danielkent8" target="_blank" style="color:var(--acc)">Daniel Kent</a> ·
-      <a href="https://www.artstation.com/mekval" target="_blank" style="color:var(--acc)">Mekval</a></p>
-      <p>Mentor: <a href="https://www.artstation.com/bronzegear" target="_blank" style="color:var(--acc)">Bronzegear</a> &nbsp;·&nbsp; Special thanks: <a href="https://www.artstation.com/timothydries" target="_blank" style="color:var(--acc)">Timothy Dries</a> · <a href="https://www.artstation.com/sunnyday" target="_blank" style="color:var(--acc)">Sunnyday</a></p>`,
+      <a href="https://www.artstation.com/jackshergold" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Jack Shergold</a> ·
+      <a href="https://www.artstation.com/joebates1" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Joe Bates</a> ·
+      <a href="https://www.artstation.com/danielkent8" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Daniel Kent</a> ·
+      <a href="https://www.artstation.com/mekval" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Mekval</a></p>
+      <p>Mentor: <a href="https://www.artstation.com/bronzegear" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Bronzegear</a> &nbsp;·&nbsp; Special thanks: <a href="https://www.artstation.com/timothydries" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Timothy Dries</a> · <a href="https://www.artstation.com/sunnyday" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Sunnyday</a></p>`,
     studio:'Beyond Extent',project:"Witch's Den Team Challenge",year:'Nov 2025',engine:'Unreal Engine 5',
     sw:['Maya','ZBrush','Substance Painter','UE5','Marmoset Toolbag'],
     images:[
@@ -1440,7 +1440,7 @@ function showPost(id){
   // TS download button
   const dlWrap=document.getElementById('ts-dl');
   if(p.tsUrl){
-    dlWrap.innerHTML=`<a href="${p.tsUrl}" target="_blank" rel="noopener" class="ts-dl-btn">
+    dlWrap.innerHTML=`<a href="${p.tsUrl}" target="_blank" rel="noopener noreferrer" class="ts-dl-btn">
       <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
       Download TimeSplitters: Rewind — Free
     </a>
@@ -1459,7 +1459,7 @@ function showPost(id){
     <div class="sb"><div class="sbl">Year</div><div class="sbv m">${p.year}</div></div>
     <div class="sb"><div class="sbl">Engine / Renderer</div><div class="sbv">${p.engine}</div></div>
     <div class="sb"><div class="sbl">Software</div><div class="swl">${p.sw.map(s=>`<span class="sw">${s}</span>`).join('')}</div></div>
-    ${p.artstation?`<div class="sb"><div class="sbl">ArtStation Post</div><a href="${p.artstation}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:.4rem;font-size:.78rem;color:var(--acc);text-decoration:none;margin-top:.1rem;transition:color .2s" onmouseover="this.style.color='var(--txt)'" onmouseout="this.style.color='var(--acc)'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>View on ArtStation ↗</a></div>`:''}
+    ${p.artstation?`<div class="sb"><div class="sbl">ArtStation Post</div><a href="${p.artstation}" target="_blank" rel="noopener noreferrer" style="display:inline-flex;align-items:center;gap:.4rem;font-size:.78rem;color:var(--acc);text-decoration:none;margin-top:.1rem;transition:color .2s" onmouseover="this.style.color='var(--txt)'" onmouseout="this.style.color='var(--acc)'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>View on ArtStation ↗</a></div>`:''}
   `;
 
   // gallery — masonry, handles mixed img + video items
@@ -1504,7 +1504,7 @@ function showPost(id){
   if(p.team && p.team.length){
     const liIcon=`<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-2-2 2 2 0 00-2 2v7h-4v-7a6 6 0 016-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>`;
     const mentorHTML=p.mentor?`
-      <a class="credcard mentor" href="https://www.linkedin.com/search/results/people/?keywords=${encodeURIComponent(p.mentor.name)}" target="_blank" rel="noopener">
+      <a class="credcard mentor" href="https://www.linkedin.com/search/results/people/?keywords=${encodeURIComponent(p.mentor.name)}" target="_blank" rel="noopener noreferrer">
         <img src="${p.mentor.img}" alt="${p.mentor.name}" loading="lazy">
         <div class="cred-mentor-info">
           <span class="cred-mentor-badge">Mentor</span>
@@ -1514,7 +1514,7 @@ function showPost(id){
         </div>
       </a>`:'';
     const memberHTML=p.team.map(m=>`
-      <a class="credcard" href="${m.li}" target="_blank" rel="noopener">
+      <a class="credcard" href="${m.li}" target="_blank" rel="noopener noreferrer">
         <img src="${m.img}" alt="${m.name}" loading="lazy">
         <div>
           <div class="credname">${m.name}</div>

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,15 @@
   "outputDirectory": "public",
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    },
+    {
       "source": "/wp-content/uploads/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## Summary
- Add `rel="noopener noreferrer"` to all 24 `target="_blank"` links (11 were missing it)
- Add security response headers via vercel.json:
  - `X-Content-Type-Options: nosniff` — prevents MIME type sniffing
  - `X-Frame-Options: DENY` — prevents clickjacking via iframes
  - `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage
  - `Permissions-Policy: camera=(), microphone=(), geolocation=()` — disables unused browser APIs

## Test plan
- [ ] Verify site loads correctly at preview URL
- [ ] Check response headers with browser DevTools (Network tab → select document → Headers)
- [ ] Verify external links still open in new tabs
- [ ] Confirm no console errors

Generated with [Claude Code](https://claude.ai/code)