### PR TITLE
fix: update stale wireframe.jpg reference to .webp

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1185,7 +1185,7 @@ const POSTS={
       {src:'/wp-content/uploads/2025/10/cryogen-case-thumbnail.webp', fw:false, type:'img', label:'Cryogen Case — Thumbnail'},
       {src:'/wp-content/uploads/2024/10/PlanetXBrain2.webp', fw:true, type:'img', label:'Planet X — Hero'},
       {src:'/wp-content/uploads/2024/10/PlanetXBrain3.webp', fw:false, type:'img', label:'Planet X — Brain'},
-      {src:'/wp-content/uploads/2024/06/wireframe.jpg', fw:false, type:'img', label:'Wireframe'},
+      {src:'/wp-content/uploads/2024/06/wireframe.webp', fw:false, type:'img', label:'Wireframe'},
       {src:'/wp-content/uploads/2024/06/giovanni-lauffer-screenshot002.webp', fw:false, type:'img', label:'Screenshot 002'},
       {src:'/wp-content/uploads/2024/06/giovanni-lauffer-screenshot001-1.webp', fw:false, type:'img', label:'Screenshot 001'},
       {src:'/wp-content/uploads/2024/06/giovanni-lauffer-screenshot001.webp', fw:false, type:'img', label:'Screenshot 001b'},


### PR DESCRIPTION
## Summary
- Fixed 1 remaining asset reference pointing to `wireframe.jpg` (pre-optimization filename)
- File was already converted to `wireframe.webp` during optimization but this JS data reference was missed

## Audit result
Full scan confirms **0 missing assets** after this fix. All 148 referenced paths resolve to existing files.

Generated with [Claude Code](https://claude.ai/code)