### PR TITLE
Orange hand cursor, bigger size, no OS cursor leak

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,14 +46,15 @@ html{scroll-behavior:smooth}
 body{background:var(--bg);color:var(--txt);font-family:var(--fb);font-weight:300;overflow-x:hidden;cursor:none}
 
 /* ── CURSOR ── */
+*,a,button,input,select,textarea,[role="button"]{cursor:none!important}
 #cur{position:fixed;width:8px;height:8px;background:var(--acc);border-radius:50%;pointer-events:none;z-index:9999;transform:translate(-50%,-50%);transition:width .15s,height .15s,background .2s,border-radius .2s}
-#cur .cur-hand{position:absolute;top:50%;left:50%;width:0;height:0;opacity:0;transform:translate(-50%,-50%) rotate(-15deg);transition:width .2s,height .2s,opacity .15s,transform .25s cubic-bezier(.34,1.56,.64,1);pointer-events:none}
+#cur .cur-hand{position:absolute;top:50%;left:50%;width:0;height:0;opacity:0;transform:translate(-50%,-50%) rotate(-20deg);transition:width .25s,height .25s,opacity .15s,transform .3s cubic-bezier(.34,1.56,.64,1);pointer-events:none}
 #curR{position:fixed;width:34px;height:34px;border:1px solid rgba(14,184,160,.35);border-radius:50%;pointer-events:none;z-index:9998;transform:translate(-50%,-50%);transition:left .08s ease-out,top .08s ease-out,width .18s,height .18s,border-color .2s}
 body.hov #cur{width:6px;height:6px;background:transparent;border-radius:0}
-body.hov #cur .cur-hand{width:22px;height:22px;opacity:1;transform:translate(-35%,-55%) rotate(0deg)}
-body.hov #curR{width:50px;height:50px;border-color:rgba(14,184,160,.55)}
-body.clicking #cur .cur-hand{transform:translate(-35%,-55%) rotate(5deg) scale(.88);transition-duration:.08s}
-body.clicking #curR{width:42px;height:42px;border-color:rgba(14,184,160,.9)}
+body.hov #cur .cur-hand{width:32px;height:32px;opacity:1;transform:translate(-35%,-55%) rotate(0deg)}
+body.hov #curR{width:56px;height:56px;border-color:rgba(249,115,22,.55)}
+body.clicking #cur .cur-hand{transform:translate(-35%,-55%) rotate(8deg) scale(.82);transition-duration:.08s}
+body.clicking #curR{width:44px;height:44px;border-color:rgba(249,115,22,.9)}
 
 /* ── NAV ── */
 nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:center;gap:1.5rem;padding:1.2rem 2.5rem;background:linear-gradient(to bottom,rgba(13,13,14,.98),transparent)}
@@ -337,8 +338,8 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 
 /* ── REDUCED MOTION ── */
 @media(prefers-reduced-motion:reduce){
-  *,*::before,*::after{animation-duration:0.01ms!important;animation-iteration-count:1!important;transition-duration:0.01ms!important;scroll-behavior:auto!important}
-  body{cursor:auto}
+  *,*::before,*::after{animation-duration:0.01ms!important;animation-iteration-count:1!important;transition-duration:0.01ms!important;scroll-behavior:auto!important;cursor:auto!important}
+  body{cursor:auto!important}
   #cur,#curR{display:none}
   .pcard img.thumb,.gi img,.relcard img{transition:none}
   .rslides{transition:none}
@@ -382,9 +383,9 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
    RESPONSIVE — TABLET (≤900px)
 ════════════════════════════════════ */
 @media(max-width:900px){
-  /* cursor hidden on touch */
+  /* cursor restored on mobile */
+  *,a,button,input,select,textarea,[role="button"]{cursor:auto!important}
   #cur,#curR{display:none}
-  body{cursor:auto}
 
   /* nav: hide links, show hamburger */
   nav{padding:1rem 1.4rem}
@@ -494,7 +495,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 </head>
 <body>
 
-<div id="cur" aria-hidden="true"><svg class="cur-hand" viewBox="0 0 24 28" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 1v12M10 1C10 1 10 1 8 1S6 2.5 6 3.5V11M10 1c0 0 0 0 2 0s2 1.5 2 2.5V11M14 5c1.5 0 2.5.8 2.5 2.5V11M6 11c-1.8 0-3 1.2-3 3v3c0 5 3.5 8 7.5 8S18 22 18 17v-6" stroke="#0EB8A0" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></div>
+<div id="cur" aria-hidden="true"><svg class="cur-hand" viewBox="0 0 24 28" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 1v12M10 1C10 1 10 1 8 1S6 2.5 6 3.5V11M10 1c0 0 0 0 2 0s2 1.5 2 2.5V11M14 5c1.5 0 2.5.8 2.5 2.5V11M6 11c-1.8 0-3 1.2-3 3v3c0 5 3.5 8 7.5 8S18 22 18 17v-6" stroke="#F97316" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></div>
 <div id="curR" aria-hidden="true"></div>
 
 <!-- Mobile nav overlay -->


### PR DESCRIPTION
Cursor refinements: orange hand + ring, 32px size, cursor:none!important kills OS hand. Tested locally.