### PR TITLE
Archive Impersonator project from portfolio

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1191,7 +1191,7 @@ const POSTS={
       {t:'Baking Workflow',b:'Normal, AO, and curvature maps baked from the ZBrush sculpt onto a low-poly mesh in Substance Painter. Polycount minimal while the normal map carries all organic complexity.'},
       {t:'Texturing',b:'Metallic sci-fi container with frost edge wear. Brain textured as a preserved biological specimen — slightly discoloured, suspended in fluid suggested by the container\'s transparent panel.'},
     ],
-    rel:['turret','impersonator','bulletproof']
+    rel:['turret','crane','bulletproof']
   },
   shoal:{
     id:'shoal',cat:'ts',
@@ -1217,7 +1217,7 @@ const POSTS={
       {t:'Companion Fish',b:'A hero fish mesh instanced and varied in scale and pose to create the illusion of a dynamic school surrounding the main character.'},
       {t:'Materials',b:'Slick cetacean skin, dapper hat fabric, worn pipe wood, and bright iridescent scales on the companion fish — each material reinforcing the character\'s comic personality.'},
     ],
-    rel:['impersonator','cryogen','turret']
+    rel:['shoal','cryogen','turret']
   },
   motorcycle:{
     id:'motorcycle',cat:'personal',
@@ -1356,7 +1356,7 @@ const POSTS={
 };
 
 // ── order for grid display (Beyond Extent first, then gaming, CGI last) ──
-const ORDER=['witchden','turret','spaceship','helicopter','impersonator','airplane','carousel','crane','bulletproof','cryogen','shoal','motorcycle','grabaduck','rituals'];
+const ORDER=['witchden','turret','spaceship','helicopter','airplane','carousel','crane','bulletproof','cryogen','shoal','motorcycle','grabaduck','rituals'];
 
 // ── render portfolio grid ──
 function renderGrid(filter){


### PR DESCRIPTION
Remove Impersonator from grid — no new images in ArtStation batch. Data preserved in code for future use. Related project links updated.