### PR TITLE
Update contact email per Gio's request

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -571,7 +571,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
   <a href="#" onclick="showPortfolio();closeMob();return false">Portfolio</a>
   <a href="https://www.artstation.com/giovannilauffer" target="_blank" rel="noopener noreferrer" onclick="closeMob()">ArtStation</a>
   <a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank" rel="noopener noreferrer" onclick="closeMob()">LinkedIn</a>
-  <a href="mailto:giovanni@giovannilauffer.com" class="mob-cta">Hire Me</a>
+  <a href="mailto:giovannielauffer@gmail.com" class="mob-cta">Hire Me</a>
 </div>
 
 <nav aria-label="Main navigation">
@@ -585,7 +585,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
     <li><a href="https://www.artstation.com/giovannilauffer" target="_blank" rel="noopener noreferrer">ArtStation</a></li>
     <li><a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
   </ul>
-  <a href="mailto:giovanni@giovannilauffer.com" class="ncta">Hire Me</a>
+  <a href="mailto:giovannielauffer@gmail.com" class="ncta">Hire Me</a>
   <button class="musicbtn" id="musicbtn" onclick="toggleMusic()" title="Toggle music" aria-label="Toggle background music">
     <svg id="musicicon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5">
       <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
@@ -674,7 +674,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
           View Portfolio
           <svg viewBox="0 0 24 24" width="15" height="15" stroke="currentColor" stroke-width="1.8" fill="none"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
         </a>
-        <a href="mailto:giovanni@giovannilauffer.com" class="bsec">Get In Touch</a>
+        <a href="mailto:giovannielauffer@gmail.com" class="bsec">Get In Touch</a>
         <a href="/giovanni-lauffer-cv.pdf" download class="bsec" target="_blank" rel="noopener noreferrer">Download CV</a>
       </div>
     </div>
@@ -921,16 +921,16 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         <a href="https://www.artstation.com/giovannilauffer" target="_blank" rel="noopener noreferrer">ArtStation</a>
         <a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
         <a href="#" onclick="showPortfolio();return false">Portfolio</a>
-        <a href="mailto:giovanni@giovannilauffer.com">Get In Touch</a>
+        <a href="mailto:giovannielauffer@gmail.com">Get In Touch</a>
       </div>
       <div class="footer-copy">&copy; 2026 Giovanni Lauffer &middot; All rights reserved</div>
     </div>
     <div class="footer-cta">
-      <a href="mailto:giovanni@giovannilauffer.com" class="bprim">
+      <a href="mailto:giovannielauffer@gmail.com" class="bprim">
         Hire Me
         <svg viewBox="0 0 24 24" width="14" height="14" stroke="currentColor" stroke-width="1.8" fill="none"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
       </a>
-      <div class="footer-email">giovanni@giovannilauffer.com</div>
+      <div class="footer-email">giovannielauffer@gmail.com</div>
     </div>
   </footer>
 
@@ -996,7 +996,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
     <a href="https://www.artstation.com/giovannilauffer" target="_blank" rel="noopener noreferrer" class="hl hls">ArtStation</a>
     <a href="https://www.linkedin.com/in/giovanni-lauffer-08558b185/" target="_blank" rel="noopener noreferrer" class="hl hls">LinkedIn</a>
     <a href="/giovanni-lauffer-cv.pdf" download target="_blank" rel="noopener noreferrer" class="hl hls">Download CV</a>
-    <a href="mailto:giovanni@giovannilauffer.com" class="hl hlp">Contact Me →</a>
+    <a href="mailto:giovannielauffer@gmail.com" class="hl hlp">Contact Me →</a>
   </div>
 </div>
 


### PR DESCRIPTION
## What Giovanni Asked For
Change the contact email from giovanni@giovannilauffer.com to giovannielauffer@gmail.com

## What Changed
- All 7 email references (mailto links + footer display) updated to giovannielauffer@gmail.com
- Affects: mobile Hire Me, nav Hire Me, Get In Touch buttons, footer email, hire bar Contact Me

## Files Modified
- `public/index.html` — updated all mailto: links and the visible email text in the footer

## How to Verify
1. Open the Vercel preview URL
2. Scroll to the bottom — footer email should show giovannielauffer@gmail.com
3. Click any "Hire Me" / "Get In Touch" / "Contact Me" button — should open email to the new address

## Risk Level
Low — text-only changes to email addresses

## Notes for Jonny
- The "Cinder Interactive" tag on the TimeSplitters showreel slide is already in the code (line 621). Gio may have been looking at the old deployment before PR #26 merged. Worth confirming he sees it now.

🤖 Generated with [Claude Code](https://claude.ai/code)