### PR TITLE
Fix color contrast to pass mobile accessibility audit

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
 :root{
   --bg:#0d0d0e;--surf:#161618;--surf2:#1e1e21;
   --brd:rgba(255,255,255,0.08);--brd2:rgba(255,255,255,0.16);
-  --txt:#eeebe5;--mut:#6e6b65;
+  --txt:#eeebe5;--mut:#908d88;
   /* dual accent: teal primary, orange secondary */
   --acc:#0eb8a0;       /* teal */
   --acc2:#f4845f;      /* orange */
@@ -371,7 +371,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .footer-links{display:flex;gap:1.8rem;margin-top:1.2rem;flex-wrap:wrap}
 .footer-links a{font-size:.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--mut);text-decoration:none;font-weight:500;transition:color .2s}
 .footer-links a:hover{color:var(--acc)}
-.footer-copy{font-size:.6rem;color:rgba(110,107,101,.4);margin-top:.85rem;letter-spacing:.06em}
+.footer-copy{font-size:.6rem;color:var(--mut);margin-top:.85rem;letter-spacing:.06em}
 .footer-cta{display:flex;flex-direction:column;align-items:flex-end;gap:.8rem}
 .footer-cta .bprim{font-size:.68rem;padding:.72rem 1.5rem;white-space:nowrap}
 .footer-email{font-size:.68rem;color:var(--mut);letter-spacing:.04em;font-family:var(--fm)}
@@ -445,7 +445,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 .htxt strong{color:var(--txt);margin-right:.3rem}
 .hact{display:flex;gap:.6rem}
 .hl{font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;padding:.5rem 1.2rem;font-weight:500;text-decoration:none;transition:all .2s;font-family:var(--fb);border-radius:9999px}
-.hlp{background:var(--acc2);color:#fff}
+.hlp{background:var(--acc2);color:#0d0d0e}
 .hlp:hover{background:#f07030}
 .hls{border:1px solid var(--brd);color:var(--mut)}
 .hls:hover{border-color:var(--brd2);color:var(--txt)}


### PR DESCRIPTION
## What Giovanni Asked For
Run a mobile Lighthouse audit and fix the one failing accessibility issue (color contrast).

## What Changed
- All muted/secondary text is slightly brighter (warmer gray, still subtle but readable)
- Copyright line in footer is now visible instead of nearly invisible
- "Contact Me →" button now uses dark text on orange (easier to read)

## Files Modified
- `public/index.html` — 3 CSS color value changes

## How to Verify
1. Open the Vercel preview URL
2. Check the footer — copyright text should now be visible
3. Check the "Contact Me →" orange button — text should be dark instead of white
4. Run Lighthouse mobile audit to confirm accessibility score hits 100

## Risk Level
Low — CSS color changes only, no layout or structure changes

## Notes for Jonny
Mobile Lighthouse scores before fix: Accessibility 96, Best Practices 100, SEO 100.
The failing audit was color-contrast. Three CSS values changed:
- `--mut` variable: `#6e6b65` → `#908d88` (affects all muted text site-wide)
- `.footer-copy`: `rgba(110,107,101,.4)` → `var(--mut)` (was 1.53:1 contrast, nearly invisible)
- `.hlp` button text: `#fff` → `#0d0d0e` (white on orange was 2.52:1, dark on orange gives 7.8:1)