### PR TITLE
Fix mobile showreel not autoplaying on first load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1520,6 +1520,8 @@ function ps(){gts(cs-1);}
 // expose to onclick handlers
 window.gts=gts; window.ns=ns; window.ps=ps;
 at=setTimeout(()=>gts(1),7000);
+// explicitly play slide 0 video — HTML autoplay is unreliable on mobile
+(function(){const v=document.querySelectorAll('.slide-video')[0];if(v)v.play&&v.play().catch(()=>{});})();
 
 // ── image base ──
 const B='/wp-content/uploads/';


### PR DESCRIPTION
## What Giovanni Asked For
On mobile, the showreel sometimes loads paused — showing the spaceship thumbnail and a video player icon instead of playing automatically like on desktop.

## What Changed
- Added one line of JS to explicitly call `.play()` on the first slide video when the page loads

## Files Modified
- `public/index.html` — one line added after the reel slide timer setup

## How to Verify
1. Open the Vercel preview URL on a real phone (or Chrome DevTools mobile emulation)
2. Load the page fresh — the showreel should start playing immediately with no pause icon or thumbnail visible

## Risk Level
Low — single line change, no layout or logic changes. Only affects the initial video play call on page load.

## Notes for Jonny
Root cause: the reel's `gts()` function calls `.play()` explicitly when switching slides, but was never called for slide 0 on initial load — it relied purely on the HTML `autoplay` attribute. Mobile browsers (iOS Safari, Android Chrome) frequently ignore the `autoplay` attribute on page load even for muted videos, which is why the poster image (spaceship) and paused state appeared. The fix mirrors exactly what `gts()` already does for every other slide.