### PR TITLE
Fix showreel videos always restarting from the beginning

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1510,7 +1510,7 @@ function gts(n){
   document.getElementById('rtim').textContent=`0${cs+1} / 0${T}`;
   // play active slide video, pause others
   document.querySelectorAll('.slide-video').forEach((v,i)=>{
-    if(i===cs){v.play && v.play().catch(()=>{});}
+    if(i===cs){v.currentTime=0; v.play && v.play().catch(()=>{});}
     else{v.pause && v.pause();}
   });
   clearTimeout(at); at=setTimeout(()=>gts(cs+1),7000);


### PR DESCRIPTION
## What Giovanni Asked For
Witches Den (and any other reel video) sometimes cuts in mid-clip or hits the end and loops awkwardly. Every video should always start from 0 when its slide comes up — never continue from where it left off.

## What Changed
- **Reel slide switch logic** — added `v.currentTime = 0` before calling `.play()` on the incoming slide's video. One character change, zero risk.

## Files Modified
- `public/index.html` — 1 line changed in the `gts()` reel function

## How to Verify
1. Open the site and let the showreel auto-advance through all 4 slides a couple of times
2. Watch Witches Den specifically — it should always start from the beginning, never mid-clip
3. Also click the dots/arrows to manually jump to a slide repeatedly — same result

## Risk Level
Low — single-line JS change in an isolated function. No layout, no CSS, no other logic touched.

## Notes for Jonny
Applies to both desktop and mobile. The fix is in the shared `gts()` function so it covers all paths (auto-advance, dot click, arrow click).