### PR TITLE
Show personal photo strip on mobile About page + fix tablet layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -495,6 +495,12 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 
   /* about: single column */
   .about{grid-template-columns:1fr;gap:2.5rem;padding:3rem 1.4rem 3rem}
+  /* about hero: stack on tablets — prevents 3-col from cramping at iPad-portrait widths */
+  .about-hero-top{flex-direction:column;align-items:flex-start;padding:7rem 1.4rem 2rem;gap:2rem}
+  .about-photo-strip{display:none}
+  #about .about-hero-inner{max-width:100%}
+  .about-hero-photo{width:100%;height:300px}
+  .aps-track img{height:300px;width:210px}
 
   /* work: single column */
   .witems{grid-template-columns:1fr}
@@ -598,12 +604,13 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 
   /* about page: tighter spacing on mobile */
   #about .about-hero{flex-direction:column}
-  .about-hero-top{padding:7rem 1.4rem 2rem;flex-direction:column;align-items:flex-start;gap:2rem}
-  .about-photo-strip{display:none}
-  #about .about-hero-inner{max-width:100%}
+  .about-hero-top{padding:7rem 1.4rem 0;flex-direction:column;align-items:flex-start;gap:2rem}
+  #about .about-hero-inner{max-width:100%;order:1}
   #about .about-hero-inner h1{font-size:clamp(2.4rem,10vw,3.5rem)}
-  .about-hero-photo{width:100%;height:280px}
-  .aps-track img{height:280px;width:200px}
+  .about-hero-photo{order:2;width:100%;height:280px}
+  /* photo strip: show below profile photo, compact height, full-bleed */
+  .about-photo-strip{display:block;order:3;height:140px;margin-left:-1.4rem;margin-right:-1.4rem}
+  .aps-track img{height:140px;width:105px}
   #about .about-body{padding:0 1.4rem 6rem}
   .about-block{grid-template-columns:1fr;gap:.75rem;padding-left:1rem}
   .about-block-img{grid-template-columns:1fr}


### PR DESCRIPTION
## What Giovanni Asked For
The personal photo strip (auto-scrolling marquee of Gio's photos) was missing on mobile — only the games strip was visible. Giovanni wanted it shown on mobile, below the profile photo. Also asked whether tablets/landscape/all devices look good.

## What Changed
- **Mobile (≤540px)** — photo strip now shows below the profile photo at 140px height, full edge-to-edge bleed. Text → profile photo → photo strip in that order. Was previously `display:none`.
- **Tablet (≤900px)** — added about-hero stacking to the 900px block. Previously the 3-column desktop layout (text + strip + photo) was used all the way down to tablet, which caused text and photo to cramp/overflow the strip at iPad-portrait widths (~768px). Now stacks cleanly at any tablet size.

## Files Modified
- `public/index.html` — CSS changes only in `@media(max-width:900px)` and `@media(max-width:540px)` blocks

## How to Verify
1. Open preview on a phone — scroll the About page to see the photo strip appear below the profile photo, auto-scrolling
2. Open DevTools at 768px width (iPad portrait) — about hero should stack cleanly, no cramping
3. Desktop (>900px) — no change, 3-col layout still intact

## Risk Level
Low — CSS-only changes, about page only. Desktop untouched. 

## Notes for Jonny
- Steam Deck (1280×800) uses full desktop layout — already fine, no changes needed
- Landscape phones (667px wide) hit the ≤900px block which now stacks the about hero — looks correct
- Games strip was already visible on mobile (not hidden), so no change needed there