### PR TITLE
Mobile & tablet polish, thumbnails, quote update + auto-updating year

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -977,7 +977,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
       </div>
     </div>
 
-    <div id="scroll-hint" aria-hidden="true" onclick="(function(){var el=document.querySelector('.about.reveal');window.scrollTo({top:el.offsetTop-window.innerHeight+672,behavior:'smooth'});})();">
+    <div id="scroll-hint" aria-hidden="true" onclick="(function(){var el=document.querySelector('.about.reveal');if(el)el.scrollIntoView({behavior:'smooth'});})();">
       <span>Resume &amp;<em>Recommendations</em></span>
       <svg width="18" height="22" viewBox="0 0 18 22" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="2 2 9 9 16 2"/>


### PR DESCRIPTION
## What Giovanni Asked For
1. Mobile + tablet polish across the whole site
2. Fix cut-off related project thumbnails
3. Add scroll room so thumbnails aren't hidden by the hire bar
4. Update the About page quote
5. Footer year and About page year counter update automatically every year — no manual changes needed

---

## What Changed

### Auto-updating year (footer + About page counter)
- **Footer copyright** `© 2026`: now reads from the browser clock — will show 2027, 2028, etc. automatically every new year
- **About page background counter** on "Right Now" + "What I'm After" story blocks: same — always shows the current year. Historical dates (1994, 2002, 2007, 2020) stay hardcoded as intended.
- Graceful fallback: `2026` remains in the HTML — if JS fails to load, it shows 2026 instead of blank

### About page — quote update (all versions)
- **Old:** "The world is the reference. I'm just taking notes."
- **New:** "Travel is how I stock my reference folder."

### All screen sizes — project detail pages
- **Related project thumbnails**: `aspect-ratio:4/3` → `1/1` — square like the portfolio grid
- **Scroll room below thumbnails**: bottom padding `5rem` → `12rem`

### Tablet (≤900px)
- **Slide label**: back to bottom-right
- **Hero buttons**: Download CV below View Portfolio; Get In Touch stays next to it
- **About page reorder**: profile pic+hobbies → photo strip+quote → MY STORY
- **Profile pic + hobbies**: centered horizontally
- **Photo strip**: now visible (160px height)

### Mobile (≤540px)
- **Scroll hint**: orange arrow only, text hidden
- **About page order**: pic → hobbies → strip → quote → MY STORY
- **Quote**: centered with equal spacing above and below

**Desktop layout and all JS logic otherwise untouched.**

## Files Modified
- `public/index.html` — quote text, footer span, data-year attributes, JS year handler, CSS breakpoints

## How to Verify
1. **Footer** → reads `© 2026` (current year)
2. **About page → scroll to "Right Now" section** → background counter shows 2026
3. **About page** → quote reads "Travel is how I stock my reference folder."
4. **Any project page → scroll to bottom** → square thumbnails, fully visible above hire bar
5. **DevTools → 768px (iPad)**: Download CV under View Portfolio. About: pic centered, correct order.
6. **DevTools → 375px (iPhone)**: Arrow-only scroll hint. About: correct order, quote centered.

## Risk Level
Low — CSS and small JS additions only. No existing logic removed. All changes degrade gracefully.

---

## Device Testing Checklist for Jonny

### ✅ Tested & signed off
| Device | Size | Orientation |
|--------|------|-------------|
| Desktop | ~1440px | — |
| iPad (standard) | 768px | Portrait |
| iPhone (standard) | 375px | Portrait |

### ⚠️ NOT tested — please check & fix in a follow-up branch

| Gap | Details |
|-----|---------|
| **Phone landscape** | Needs `@media(orientation:landscape) and (max-width:900px)` — reel gets very short, hero text likely clips |
| **900–1100px range** | iPad landscape (1024px), iPad Pro portrait, large Android tablets, Surface Pro all hit desktop styles on touch screens |
| **Z Fold cover screen** | ~260px wide — likely broken |
| **Ultrawide (Sharlon's setup)** | 1920px, 2560px, 3440px — layout may spread too thin, consider max-width caps |
| **Z Flip/Razr open** | ~673px — covered by tablet breakpoint, worth a quick check |
| **Z Fold open** | ~904px — just above tablet breakpoint, hits desktop on a phone screen |
| **Small Android phones** | 360px — just below iPhone 375px, quick sanity check |