### PR TITLE
Visual polish — sunset, white unification, contact form, filters (clean)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
 .aps-track img,.gstr-track img,.ablock-img-wrap img{-webkit-user-drag:none;user-drag:none;-webkit-user-select:none;user-select:none}
 :root{
   --bg:#0d0d0e;--surf:#161618;--surf2:#1e1e21;
-  --brd:rgba(255,255,255,0.08);--brd2:rgba(255,255,255,0.16);
+  --brd:rgba(238,235,229,0.08);--brd2:rgba(238,235,229,0.16);
   --txt:#eeebe5;--mut:#908d88;
   /* dual accent: teal primary, orange secondary */
   --acc:#0eb8a0;       /* teal */
@@ -67,7 +67,7 @@ body.hov #cursor{width:28px;height:28px}
 nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:center;gap:1.5rem;padding:1.2rem 2.5rem;background:linear-gradient(to bottom,rgba(13,13,14,.98),transparent)}
 .nlogo{height:40px;cursor:none;display:flex;align-items:center;position:relative}
 .nlogo img{height:100%;width:auto}
-.nlogo::after{content:'';position:absolute;top:13px;left:13px;width:14px;height:14px;background:#fff;border-radius:50%;transform:scaleY(0);transform-origin:center top;animation:lidblink 4s ease-in-out infinite;pointer-events:none;z-index:1}
+.nlogo::after{content:'';position:absolute;top:13px;left:13px;width:14px;height:14px;background:#eeebe5;border-radius:50%;transform:scaleY(0);transform-origin:center top;animation:lidblink 4s ease-in-out infinite;pointer-events:none;z-index:1}
 @keyframes lidblink{0%,80%{transform:scaleY(0)}84%{transform:scaleY(1)}88%,100%{transform:scaleY(0)}}
 .nlogo span{font-family:var(--fd);font-size:1.3rem;letter-spacing:.1em;color:var(--txt)}
 .musicbtn{background:none;border:1px solid var(--brd);color:var(--mut);width:36px;height:36px;display:flex;align-items:center;justify-content:center;cursor:none;transition:border-color .2s,color .2s;flex-shrink:0;border-radius:9999px}
@@ -93,11 +93,11 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .rslides{display:flex;height:100%;transition:transform .9s cubic-bezier(.77,0,.18,1)}
 .rslide{min-width:100%;height:100%;position:relative;flex-shrink:0;overflow:hidden}
 .rslide video{width:100%;height:100%;object-fit:cover;display:block}
-.rslide .vfb{width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-family:var(--fe);font-size:6rem;font-weight:800;letter-spacing:.04em;color:rgba(255,255,255,.03)}
+.rslide .vfb{width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-family:var(--fe);font-size:6rem;font-weight:800;letter-spacing:.04em;color:rgba(238,235,229,.03)}
 .fb1{background:linear-gradient(135deg,#030d0b,#071a14,#0a241c)}
 .fb2{background:linear-gradient(135deg,#0a0808,#180f0f,#200a0a)}
-.fb3{background:linear-gradient(135deg,#06080f,#0c1020,#080614);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--fe);font-size:6rem;font-weight:800;letter-spacing:.04em;color:rgba(255,255,255,.03)}
-.fb4{background:linear-gradient(135deg,#0c0a10,#18101e,#100c08);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--fe);font-size:6rem;font-weight:800;letter-spacing:.04em;color:rgba(255,255,255,.03)}
+.fb3{background:linear-gradient(135deg,#06080f,#0c1020,#080614);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--fe);font-size:6rem;font-weight:800;letter-spacing:.04em;color:rgba(238,235,229,.03)}
+.fb4{background:linear-gradient(135deg,#0c0a10,#18101e,#100c08);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--fe);font-size:6rem;font-weight:800;letter-spacing:.04em;color:rgba(238,235,229,.03)}
 
 /* direct mp4 video fills slide */
 .slide-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;display:block}
@@ -136,7 +136,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
   display:block;
   position:absolute;
   top:0;left:0;right:0;
-  -webkit-text-fill-color:rgba(238,235,229,.92);
+  -webkit-text-fill-color:rgba(238,235,229,1);
   -webkit-text-stroke:0;
   clip-path:polygon(0% 100%,100% 100%,100% 62%,90% 65%,80% 60%,70% 60%,60% 65%,50% 62%,40% 59%,30% 64%,20% 64%,10% 59%,0% 62%);
   animation:milk-wave 3s ease-in-out infinite;
@@ -145,32 +145,17 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
   0%,100%{clip-path:polygon(0% 100%,100% 100%,100% 62%,90% 65%,80% 60%,70% 60%,60% 65%,50% 62%,40% 59%,30% 64%,20% 64%,10% 59%,0% 62%)}
   50%{clip-path:polygon(0% 100%,100% 100%,100% 62%,90% 59%,80% 64%,70% 64%,60% 59%,50% 62%,40% 65%,30% 60%,20% 60%,10% 65%,0% 62%)}
 }
-/* ship layer — same text-clip as milk water, above-wave area only */
-.hname .l1-ship{
+/* sunset circle — orange half-risen behind wave */
+.hname .l1-sun{
   display:block;
   position:absolute;
   top:0;left:0;right:0;
   -webkit-text-fill-color:transparent;
   color:transparent;
   -webkit-text-stroke:0;
-  background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 44 28' xmlns='http://www.w3.org/2000/svg' fill='white'%3E%3Cpath d='M2,20 L0,25 Q22,28 44,25 L42,20 Z'/%3E%3Crect x='0' y='18' width='44' height='2'/%3E%3Crect x='4' y='11' width='13' height='7'/%3E%3Crect x='6' y='6' width='9' height='5'/%3E%3Crect x='8' y='2' width='4' height='5'/%3E%3Crect x='10' y='0' width='2' height='3'/%3E%3Crect x='27' y='12' width='9' height='6'/%3E%3Crect x='29' y='7' width='5' height='5'/%3E%3Crect x='30' y='3' width='3' height='5'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;
-  background-size:40px auto;
-  background-position:23% 66%;
+  background:radial-gradient(circle 0.28em at 1.82em 65%, #f4845f 0%, #f4845f 96%, transparent 98%);
   -webkit-background-clip:text;
   background-clip:text;
-  clip-path:polygon(0% 0%,100% 0%,100% 62%,90% 65%,80% 60%,70% 60%,60% 65%,50% 62%,40% 59%,30% 64%,20% 64%,10% 59%,0% 62%);
-  animation:ship-wave 3s ease-in-out infinite;
-}
-@keyframes ship-wave{
-  0%,100%{
-    clip-path:polygon(0% 0%,100% 0%,100% 62%,90% 65%,80% 60%,70% 60%,60% 65%,50% 62%,40% 59%,30% 64%,20% 64%,10% 59%,0% 62%);
-    background-position:23% 66%
-  }
-  50%{
-    clip-path:polygon(0% 0%,100% 0%,100% 62%,90% 59%,80% 64%,70% 64%,60% 59%,50% 62%,40% 65%,30% 60%,20% 60%,10% 65%,0% 62%);
-    background-position:23% 62%
-  }
 }
 /* second line: solid teal fill */
 .hname .l2{
@@ -192,7 +177,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 
 .rctrl{position:absolute;bottom:3rem;left:2.5rem;right:2.5rem;display:flex;align-items:center;gap:1.8rem;z-index:20}
 .rdots{display:flex;gap:.45rem}
-.rdot{width:2.2rem;height:2px;background:rgba(255,255,255,.18);cursor:none;transition:background .3s,width .3s}
+.rdot{width:2.2rem;height:2px;background:rgba(238,235,229,.18);cursor:none;transition:background .3s,width .3s}
 .rdot.on{background:var(--acc);width:3.5rem}
 .rtim{font-size:.65rem;letter-spacing:.1em;color:var(--mut);font-family:var(--fm)}
 .rnav{margin-left:auto;display:flex;gap:.4rem}
@@ -210,7 +195,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 /* ── HOME: about strip ── */
 .about{display:grid;grid-template-columns:1fr 1fr;gap:5rem;padding:5rem 2.5rem 4rem;max-width:1280px;margin:0 auto}
 .sec-tag{font-size:.6rem;letter-spacing:.24em;text-transform:uppercase;color:var(--acc);font-weight:600;margin-bottom:1.2rem;display:flex;align-items:center;gap:.6rem}
-.sec-tag::before{content:'';display:block;width:1.2rem;height:1px;background:var(--acc)}
+.sec-tag::before{display:none}
 .about h2{font-family:var(--fd);font-size:2.6rem;letter-spacing:.04em;margin-bottom:1.3rem;line-height:1}
 .about p{font-size:.86rem;line-height:1.87;color:#a09c95;font-weight:300}
 .about p+p{margin-top:.9rem}
@@ -271,7 +256,16 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .pfilt{display:flex;gap:.4rem;flex-wrap:wrap}
 .fb{font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;padding:.45rem 1.1rem;border:1px solid var(--brd);background:transparent;color:var(--mut);cursor:none;transition:all .2s;font-family:var(--fb);font-weight:500;border-radius:9999px}
 .fb:hover,.fb.on{border-color:var(--acc);color:var(--acc)}
+.fb.on{animation:fb-pulse 2s ease-in-out infinite}
 .fb-beyond.on,.fb-beyond:hover{border-color:var(--acc2);color:var(--acc2)}
+.fb-beyond.on{animation:fb-pulse-orange 2s ease-in-out infinite}
+.fb-personal.on,.fb-personal:hover{border-color:var(--txt);color:var(--txt)}
+.fb-personal.on{animation:fb-pulse-white 2s ease-in-out infinite}
+.fb-cgi.on,.fb-cgi:hover{border-color:var(--txt);color:var(--txt)}
+.fb-cgi.on{animation:fb-pulse-white 2s ease-in-out infinite}
+@keyframes fb-pulse{0%,100%{box-shadow:0 0 0 0 rgba(14,184,160,0)}50%{box-shadow:0 0 8px 2px rgba(14,184,160,.35)}}
+@keyframes fb-pulse-orange{0%,100%{box-shadow:0 0 0 0 rgba(244,132,95,0)}50%{box-shadow:0 0 8px 2px rgba(244,132,95,.35)}}
+@keyframes fb-pulse-white{0%,100%{box-shadow:0 0 0 0 rgba(238,235,229,0)}50%{box-shadow:0 0 8px 2px rgba(238,235,229,.3)}}
 
 /* Portfolio grid */
 .pgrid{padding:.5rem 0 6rem;display:grid;grid-template-columns:repeat(6,1fr);gap:3px}
@@ -283,12 +277,13 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .pcc{font-size:.58rem;letter-spacing:.18em;text-transform:uppercase;color:var(--acc);font-weight:600;margin-bottom:.3rem}
 .pcn{font-family:var(--fd);font-size:1.3rem;letter-spacing:.04em;line-height:1.1}
 .pcm{display:flex;gap:.4rem;margin-top:.5rem;flex-wrap:wrap}
-.pct{font-size:.56rem;letter-spacing:.09em;text-transform:uppercase;color:rgba(238,235,229,.55);border:1px solid rgba(255,255,255,.12);padding:.18rem .45rem}
-.cbadge{position:absolute;top:.85rem;left:.85rem;font-size:.56rem;letter-spacing:.14em;text-transform:uppercase;padding:.25rem .6rem;background:var(--acc2);color:#fff;font-weight:600}
-.cgi-badge{background:var(--surf2);border:1px solid var(--brd);color:var(--mut)}
+.pct{font-size:.56rem;letter-spacing:.09em;text-transform:uppercase;color:rgba(238,235,229,.55);border:1px solid rgba(238,235,229,.12);padding:.18rem .45rem;border-radius:9999px}
+.cbadge{position:absolute;top:.85rem;left:.85rem;font-size:.56rem;letter-spacing:.14em;text-transform:uppercase;padding:.25rem .6rem;background:var(--acc2);color:#eeebe5;font-weight:600;border-radius:9999px}
+.cgi-badge{background:#1a1a1c;border:1px solid var(--brd2);color:var(--mut)}
+.beyond-badge{background:rgba(244,132,95,.12);border:1px solid rgba(244,132,95,.35);color:var(--acc2)}
 .ts-badge{background:rgba(14,184,160,.15);border:1px solid var(--acc);color:var(--acc)}
 .personal-badge{background:rgba(238,235,229,.07);border:1px solid var(--brd2);color:var(--txt)}
-.ts-dl-btn{display:inline-flex;align-items:center;gap:.65rem;background:var(--acc2);color:#fff;font-family:var(--fb);font-size:.78rem;font-weight:600;letter-spacing:.1em;text-transform:uppercase;padding:.9rem 2rem;text-decoration:none;transition:background .2s,gap .2s}
+.ts-dl-btn{display:inline-flex;align-items:center;gap:.65rem;background:var(--acc2);color:#eeebe5;font-family:var(--fb);font-size:.78rem;font-weight:600;letter-spacing:.1em;text-transform:uppercase;padding:.9rem 2rem;text-decoration:none;transition:background .2s,gap .2s}
 .ts-dl-btn:hover{background:#f07030;gap:1rem}
 .ts-dl-sub{font-size:.65rem;color:var(--mut);margin-top:.55rem;letter-spacing:.06em}
 .ts-dl-date{font-size:.68rem;color:var(--txt);margin-top:.4rem;letter-spacing:.06em;display:flex;align-items:center;gap:.5rem}
@@ -335,7 +330,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .gi{overflow:hidden;cursor:none;position:relative}
 .gi img{width:100%;height:auto;display:block;transition:transform .45s}
 .gi:hover img{transform:scale(1.03)}
-.gi .gph{width:100%;min-height:220px;display:flex;align-items:center;justify-content:center;font-family:var(--fd);font-size:1.8rem;color:rgba(255,255,255,.05)}
+.gi .gph{width:100%;min-height:220px;display:flex;align-items:center;justify-content:center;font-family:var(--fd);font-size:1.8rem;color:rgba(238,235,229,.05)}
 .gp1{background:linear-gradient(135deg,#071a14,#0d3024)}.gp2{background:linear-gradient(135deg,#1a0d07,#300d08)}.gp3{background:linear-gradient(135deg,#0d0d1a,#0d0d30)}.gp4{background:linear-gradient(135deg,#1a1a0d,#30280d)}.gp5{background:linear-gradient(135deg,#0d1a1a,#0d2828)}.gp6{background:linear-gradient(135deg,#1a0d1a,#280d28)}
 .gi.fw{}
 .gi.fw img{width:100%;height:auto;max-height:600px;object-fit:cover}
@@ -345,7 +340,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .yt-facade:hover img{opacity:.85}
 .yt-play{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:72px;height:72px;background:rgba(10,10,11,.75);border-radius:50%;display:flex;align-items:center;justify-content:center;transition:background .2s,transform .2s}
 .yt-facade:hover .yt-play{background:var(--acc2);transform:translate(-50%,-50%) scale(1.1)}
-.yt-play svg{width:28px;height:28px;fill:#fff;margin-left:4px}
+.yt-play svg{width:28px;height:28px;fill:#eeebe5;margin-left:4px}
 .yt-label{position:absolute;bottom:0;left:0;right:0;padding:.6rem .9rem;background:linear-gradient(to top,rgba(10,10,11,.9),transparent);font-size:.72rem;color:var(--txt);letter-spacing:.06em;font-weight:500}
 .yt-iframe-wrap{position:relative;width:100%;padding-bottom:56.25%;height:0;background:#000}
 .yt-iframe-wrap iframe{position:absolute;inset:0;width:100%;height:100%;border:none}
@@ -373,7 +368,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .credcard.mentor{grid-column:1/-1;flex-direction:row;text-align:left;gap:1.2rem;border-color:var(--acc2);padding:1.6rem}
 .credcard.mentor img{width:80px;height:80px;flex-shrink:0}
 .cred-mentor-info{display:flex;flex-direction:column;gap:.2rem}
-.cred-mentor-badge{font-size:.58rem;letter-spacing:.18em;text-transform:uppercase;background:var(--acc2);color:#fff;padding:.2rem .6rem;width:fit-content;font-weight:600;margin-bottom:.3rem}
+.cred-mentor-badge{font-size:.58rem;letter-spacing:.18em;text-transform:uppercase;background:var(--acc2);color:#eeebe5;padding:.2rem .6rem;width:fit-content;font-weight:600;margin-bottom:.3rem}
 @media(max-width:540px){.credgrid{grid-template-columns:repeat(2,1fr)}.credcard.mentor{flex-direction:column;text-align:center}.credcard.mentor img{width:72px;height:72px}}
 
 .relsec{margin-top:4.5rem;padding-top:2.5rem;border-top:1px solid var(--brd)}
@@ -471,18 +466,18 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 /* ── CONTACT MODAL ── */
 .cf-modal{display:none;position:fixed;inset:0;background:rgba(0,0,0,.92);z-index:1000;align-items:center;justify-content:center;padding:1rem}
 .cf-modal.on{display:flex}
-.cf-panel{background:var(--surf);border:1px solid var(--brd2);width:100%;max-width:540px;max-height:90vh;overflow-y:auto;padding:2.5rem;position:relative}
-.cf-close{position:absolute;top:1rem;right:1rem;width:44px;height:44px;border:1px solid var(--brd2);background:transparent;color:var(--txt);font-size:1.1rem;cursor:none;display:flex;align-items:center;justify-content:center;transition:border-color .2s,color .2s;border-radius:0}
+.cf-panel{background:var(--surf);border:1px solid var(--brd2);width:100%;max-width:540px;max-height:90vh;overflow-y:auto;padding:2.5rem;position:relative;border-radius:20px}
+.cf-close{position:absolute;top:1rem;right:1rem;width:44px;height:44px;border:1px solid var(--brd2);background:transparent;color:var(--txt);font-size:1.1rem;cursor:none;display:flex;align-items:center;justify-content:center;transition:border-color .2s,color .2s;border-radius:50%}
 .cf-close:hover{border-color:var(--acc);color:var(--acc)}
 .cf-tag{font-size:.6rem;letter-spacing:.24em;text-transform:uppercase;color:var(--acc);font-weight:600;margin-bottom:1rem;display:flex;align-items:center;gap:.6rem}
-.cf-tag::before{content:'';display:block;width:1.2rem;height:1px;background:var(--acc)}
+.cf-tag::before{display:none}
 .cf-title{font-family:var(--fd);font-size:2.2rem;letter-spacing:.04em;line-height:1;margin-bottom:2rem}
 .cf-title span{-webkit-text-fill-color:transparent;-webkit-text-stroke:1.5px var(--acc);color:transparent}
 .cf-row{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
 .cf-field{display:flex;flex-direction:column;gap:.4rem;margin-bottom:1rem}
 .cf-field label{font-size:.65rem;letter-spacing:.12em;text-transform:uppercase;color:var(--mut);font-weight:500}
 .cf-req{color:var(--acc2)}
-.cf-field input,.cf-field textarea{background:var(--bg);border:1px solid var(--brd2);color:var(--txt);font-family:var(--fb);font-size:.84rem;font-weight:300;padding:.72rem .9rem;width:100%;outline:none;transition:border-color .2s;-webkit-appearance:none;border-radius:0}
+.cf-field input,.cf-field textarea{background:var(--bg);border:1px solid var(--brd2);color:var(--txt);font-family:var(--fb);font-size:.84rem;font-weight:300;padding:.72rem .9rem;width:100%;outline:none;transition:border-color .2s;-webkit-appearance:none;border-radius:12px}
 .cf-field input:focus,.cf-field textarea:focus{border-color:var(--acc)}
 .cf-field textarea{resize:vertical;min-height:120px;line-height:1.7}
 .cf-field input::placeholder,.cf-field textarea::placeholder{color:var(--mut);opacity:.6}
@@ -490,8 +485,8 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 .cf-status.err{color:var(--acc2)}
 .cf-status.ok{color:var(--acc)}
 .cf-actions{display:flex;justify-content:flex-end}
-.cf-submit{display:inline-flex;align-items:center;gap:.65rem;background:var(--acc);color:var(--bg);font-family:var(--fb);font-size:.74rem;font-weight:600;letter-spacing:.1em;text-transform:uppercase;padding:.85rem 1.8rem;border:none;cursor:none;transition:background .2s,gap .2s;border-radius:9999px}
-.cf-submit:hover:not(:disabled){background:#0dd4b8;gap:1rem}
+.cf-submit{display:inline-flex;align-items:center;gap:.65rem;background:var(--acc2);color:var(--bg);font-family:var(--fb);font-size:.74rem;font-weight:600;letter-spacing:.1em;text-transform:uppercase;padding:.85rem 1.8rem;border:none;cursor:none;transition:background .2s,gap .2s;border-radius:9999px}
+.cf-submit:hover:not(:disabled){background:#e8621a;gap:1rem}
 .cf-submit:disabled{opacity:.5}
 @media(max-width:540px){.cf-panel{padding:1.8rem 1.2rem}.cf-row{grid-template-columns:1fr}.cf-title{font-size:1.8rem}}
 
@@ -636,14 +631,15 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 @media(max-width:540px){
   /* reel hero: even more compact */
   .hero{bottom:8.5rem}
-  .hname{font-size:clamp(2.6rem,13vw,4.5rem);-webkit-text-stroke:1px rgba(238,235,229,.65)}
+  .hname{font-size:clamp(3.2rem,16vw,5.5rem);-webkit-text-stroke:1px rgba(238,235,229,.65)}
   .hname .l2{-webkit-text-stroke:1.2px var(--acc)}
-  .hrole{font-size:.72rem;display:none}/* hide on tiny screens to avoid clutter */
-  .avail-hero{margin-bottom:1.2rem}
-  .htag{font-size:.58rem;margin-bottom:1.1rem}
-  .hname{margin-bottom:1.1rem}
-  .hstats{gap:1.2rem;margin-bottom:1.4rem}
-  .sn{font-size:1.4rem}
+  .hrole{font-size:.72rem;display:none}
+  .avail-hero{font-size:.54rem;margin-bottom:1rem}
+  .htag{font-size:.56rem;margin-bottom:1.1rem}
+  .hname{margin-bottom:1rem}
+  .sn{font-size:1.35rem}
+  .sl{font-size:.52rem;letter-spacing:.08em}
+  .hstats{gap:0.85rem;margin-bottom:1.4rem}
   .hbtns{display:flex;flex-direction:column;gap:.6rem;align-items:stretch}
   .bprim,.bsec{font-size:.68rem;padding:.75rem 1.4rem;justify-content:center}
 
@@ -659,7 +655,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
   .pgrid{grid-template-columns:repeat(2,1fr);padding:.5rem 0 7rem}
   .phead{padding:5rem 1rem 1.2rem}
   .pfilt{gap:.3rem}
-  .fb{font-size:.6rem;padding:.42rem .9rem;min-height:36px}
+  .fb{font-size:.6rem;padding:.42rem .9rem;min-height:36px;white-space:nowrap}
 
   /* post detail */
   .phero{height:40vh}
@@ -667,9 +663,15 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
   .pm h1{font-size:1.8rem}
   .ptags{gap:.3rem}
   .relgrid{grid-template-columns:repeat(2,1fr);margin:0 -1rem}
+  .relsec{padding-bottom:8rem}
 
   /* about */
   .about{padding:2.5rem 1rem 2.5rem}
+  .about h2{font-size:2rem;margin-bottom:1rem}
+  .about p{font-size:.82rem;line-height:1.75}
+  .wi{padding:1.4rem;gap:1rem}
+  .wt{font-size:.8rem}
+  .wdsc,.wlist{font-size:.74rem;line-height:1.75}
   .wstrip{padding:0 1rem 2.5rem}
   .rstrip{padding:0 1rem 3rem}
 
@@ -797,7 +799,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 .about-hero-logo{flex-shrink:0;display:flex;align-items:center;height:160px;position:relative}
 @media(max-width:900px){.about-hero-logo{display:none}}
 .about-hero-logo img{height:160px;width:auto;display:block}
-.about-hero-logo::after{content:'';position:absolute;top:52px;left:44px;width:72px;height:56px;background:#fff;clip-path:path('M 0 28 Q 36 0 72 28 Q 36 56 0 28 Z');transform:scaleY(0);transform-origin:center top;animation:lidblinkLg 5s linear infinite;pointer-events:none;z-index:1}
+.about-hero-logo::after{content:'';position:absolute;top:52px;left:44px;width:72px;height:56px;background:#eeebe5;clip-path:path('M 0 28 Q 36 0 72 28 Q 36 56 0 28 Z');transform:scaleY(0);transform-origin:center top;animation:lidblinkLg 5s linear infinite;pointer-events:none;z-index:1}
 @keyframes lidblinkLg{
   0%,76%{transform:scaleY(0);animation-timing-function:cubic-bezier(.7,0,1,.6)}
   79%{transform:scaleY(1);animation-timing-function:linear}
@@ -868,7 +870,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 .ablock-img-wrap{
   position:relative;border-radius:20px;overflow:hidden;
   box-shadow:0 16px 48px rgba(0,0,0,.55),0 4px 14px rgba(0,0,0,.4);
-  border:1px solid rgba(255,255,255,.08)
+  border:1px solid rgba(238,235,229,.08)
 }
 .ablock-img-wrap::after{
   content:'';position:absolute;inset:0;pointer-events:none;border-radius:20px;
@@ -887,7 +889,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 .ablock-img-wrap:hover img{transform:scale(1.06);filter:grayscale(0%)}
 .ablock-logo{
   border-radius:20px;padding:2rem;display:flex;align-items:center;justify-content:center;
-  background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.08);
+  background:rgba(238,235,229,.03);border:1px solid rgba(238,235,229,.08);
   box-shadow:0 8px 30px rgba(0,0,0,.35)
 }
 .ablock-logo img{width:100%;height:auto;object-fit:contain}
@@ -1043,7 +1045,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
     <div class="hero">
       <div class="avail-hero ai"><span class="avail-dot"></span>Available for Work</div>
       <div class="htag ai">3D Prop & Environment Artist · Ede, Netherlands</div>
-      <h1 class="hname ai d1"><span class="l1"><span class="l1-o">GIOVANNI</span><span class="l1-f" aria-hidden="true">GIOVANNI</span><span class="l1-ship" aria-hidden="true">GIOVANNI</span></span><span class="l2">LAUFFER</span></h1>
+      <h1 class="hname ai d1"><span class="l1"><span class="l1-o">GIOVANNI</span><span class="l1-sun" aria-hidden="true">GIOVANNI</span><span class="l1-f" aria-hidden="true">GIOVANNI</span></span><span class="l2">LAUFFER</span></h1>
       <p class="hrole ai d2">Props · Characters · Vehicles · Environments<br>Maya · ZBrush · Substance · UE5 · 3DS Max · VRay</p>
       <div class="hstats ai d3">
         <div><div class="sn">5+</div><div class="sl">Years Exp</div></div>
@@ -1342,8 +1344,8 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
       <button class="fb on" onclick="fc(this,'all')">All</button>
       <button class="fb fb-beyond" onclick="fc(this,'beyond')">Beyond Extent</button>
       <button class="fb" onclick="fc(this,'ts')">TimeSplitters</button>
-      <button class="fb" onclick="fc(this,'personal')">Personal</button>
-      <button class="fb" onclick="fc(this,'cgi')">CGI</button>
+      <button class="fb fb-personal" onclick="fc(this,'personal')">Personal</button>
+      <button class="fb fb-cgi" onclick="fc(this,'cgi')">CGI</button>
     </div>
   </div>
 
@@ -1747,6 +1749,13 @@ window.gts=gts; window.ns=ns; window.ps=ps;
 at=setTimeout(()=>gts(1),7000);
 // explicitly play slide 0 video — HTML autoplay is unreliable on mobile
 (function(){const v=document.querySelectorAll('.slide-video')[0];if(v)v.play&&v.play().catch(()=>{});})();
+// on first touch, unblock all slide videos so auto-advance plays them cleanly
+document.addEventListener('touchstart',function unlock(){
+  document.querySelectorAll('.slide-video').forEach(v=>{
+    if(v.paused){v.muted=true;v.play&&v.play().catch(()=>{});v.pause&&v.pause();}
+  });
+  document.removeEventListener('touchstart',unlock);
+},{once:true,passive:true});
 // scroll hint — vanishes once user scrolls
 (function(){var sh=document.getElementById('scroll-hint');if(!sh)return;window.addEventListener('scroll',function(){sh.classList.toggle('gone',window.scrollY>60);},{passive:true});})();
 
@@ -2246,7 +2255,7 @@ function renderGrid(filter){
     div.innerHTML=`
       ${thumbHTML}
       ${isCgi?`<span class="cbadge cgi-badge">CGI · Non-Gaming</span>`:''}
-      ${isBeyond?`<span class="cbadge" style="background:var(--acc2)">Beyond Extent</span>`:''}
+      ${isBeyond?`<span class="cbadge beyond-badge">Beyond Extent</span>`:''}
       ${isTs?`<span class="cbadge ts-badge">TimeSplitters: Rewind</span>`:''}
       ${isPersonal?`<span class="cbadge personal-badge">Personal Project</span>`:''}
       <div class="pcard-ov">


### PR DESCRIPTION
Replaces #45 — same features applied cleanly to current main with fixes.

## Changes
- Ship → orange sunset circle in GIOVANNI name
- All #fff unified to #eeebe5 warm off-white
- Contact form rounded corners + orange submit
- Portfolio filter pulse animations per category
- Badge pills + Beyond Extent translucent style
- Mobile hero sizing + touch video unlock

## Fixes applied
- WebP illustration paths + windsurfer naming preserved
- .bprim:hover and .cf-submit:hover get visible #e8621a
- Related projects capped at 6
- Dead #milk-clip SVG removed

Closes #45