### PR TITLE
Disable long-press save/share on all images

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@700;800&family=Bebas+Neue&family=Caveat:wght@500&family=Inter:wght@300;400;500;600&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-.aps-track img,.gstr-track img,.ablock-img-wrap img{-webkit-user-drag:none;user-drag:none;-webkit-user-select:none;user-select:none}
+img{-webkit-user-drag:none;user-drag:none;-webkit-user-select:none;user-select:none;-webkit-touch-callout:none}
 :root{
   --bg:#0d0d0e;--surf:#161618;--surf2:#1e1e21;
   --brd:rgba(238,235,229,0.08);--brd2:rgba(238,235,229,0.16);


### PR DESCRIPTION
## What Changed
- All images now have `-webkit-touch-callout:none` — prevents the iOS/Android long-press context menu (save, share, copy)
- Also applies `user-drag:none` globally (was only on photo strips)

## Files Modified
- `public/index.html` — 1 line CSS change

## Risk Level
Low — CSS only