### PR TITLE
Fix: more bottom padding on mobile/tablet (clean)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -587,7 +587,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
   .rstrip{padding:0 1.4rem 4rem}
 
   /* portfolio grid: 4 cols on tablet */
-  .pgrid{padding:.5rem 0 7rem;grid-template-columns:repeat(4,1fr)}
+  .pgrid{padding:.5rem 0 12rem;grid-template-columns:repeat(4,1fr)}
   .phead{padding:5.5rem 1.4rem 1.5rem;flex-direction:column;align-items:flex-start}
   /* portfolio filters: horizontal scroll, no wrapping */
   .pfilt{flex-wrap:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;padding-bottom:4px;max-width:100%}
@@ -654,7 +654,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
   .rbtn{width:36px;height:36px}
 
   /* portfolio: 2 columns on mobile */
-  .pgrid{grid-template-columns:repeat(2,1fr);padding:.5rem 0 7rem}
+  .pgrid{grid-template-columns:repeat(2,1fr);padding:.5rem 0 12rem}
   .phead{padding:5rem 1rem 1.2rem}
   .pfilt{gap:.3rem}
   .fb{font-size:.6rem;padding:.42rem .9rem;min-height:36px;white-space:nowrap}
@@ -708,7 +708,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
   /* photo strip: compact height, full-bleed */
   .about-photo-strip{display:block;height:140px;margin-left:-1.4rem;margin-right:-1.4rem}
   .aps-track img{height:140px;width:105px}
-  #about .about-body{padding:0 1.4rem 6rem}
+  #about .about-body{padding:0 1.4rem 12rem}
   .about-block{grid-template-columns:1fr;gap:.75rem;padding-left:1rem}
   .about-block-img{grid-template-columns:1fr}
   .ablock-img{display:none}
@@ -936,6 +936,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
   .about-label{min-width:0;padding-top:0;border-top:none;border-bottom:1px solid var(--brd);padding-bottom:.5rem}
   .about-content p{font-size:.95rem;line-height:2}
   .about-quote{font-size:1.15rem}
+  #about .about-body{padding-bottom:12rem}
 }
 @media(max-width:540px){
   .about-block{grid-template-columns:1fr;gap:.5rem}


### PR DESCRIPTION
Replaces #50 — same 4-line fix without the 70 commits of regressions.

## What Changed
- Tablet portfolio grid: bottom padding 7rem → 12rem
- Mobile portfolio grid: bottom padding 7rem → 12rem
- Mobile About body: bottom padding 6rem → 12rem
- Tablet About body: new 12rem bottom padding

Closes #50