### PR TITLE
Post videos autoplay and loop — no thumbnail or play button needed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2523,7 +2523,7 @@ function showPost(id){
     }
     if(item.type==='video'){
       return`<div class="gi${item.fw?' fw':''}">
-        <video controls loop style="width:100%;height:auto;display:block" poster="${p.thumb}">
+        <video autoplay muted loop playsinline style="width:100%;height:auto;display:block">
           <source src="${item.src}" type="video/mp4">
         </video>
       </div>`;

--- a/public/index.html
+++ b/public/index.html
@@ -2537,6 +2537,8 @@ function showPost(id){
   const has3d=p.images.some(i=>i.type==='sketchfab');
   document.querySelector('.galh').textContent=has3d?'3D Viewer & Images':'Images';
   document.getElementById('pgal').innerHTML=galHTML;
+  // explicitly play gallery videos — HTML autoplay is unreliable on mobile
+  document.querySelectorAll('#pgal video').forEach(v=>{v.play&&v.play().catch(()=>{});});
 
   // breakdown
   document.getElementById('pbd').innerHTML=`


### PR DESCRIPTION
## WARNING — VIDEO PLAYER BEHAVIOR CHANGE

This PR changes how videos behave in project post galleries. Videos now autoplay silently instead of requiring user interaction. Controls and poster attributes were removed. Review carefully.

## What Giovanni Asked For
Post videos should autoplay and loop automatically — no thumbnail or play button needed.

## What Changed
- Post gallery videos now autoplay silently on load (muted, looping, inline)
- Removed static thumbnail poster and play controls — videos behave like animated previews
- Added JS .play().catch() fallback for mobile browsers where HTML autoplay is unreliable

## Files Modified
- public/index.html — video element attributes in showPost() gallery renderer, plus JS play fallback

## How to Verify
1. Open the Vercel preview URL
2. Navigate to any project with video gallery items (e.g., Grab a Duck, Witch Den)
3. Confirm videos autoplay silently without user interaction
4. Test on mobile (iOS Safari especially) — videos should still autoplay

## Risk Level
Medium — changes video player behavior (autoplay, removes user controls)

## Notes for Jonny
- muted is required for browser autoplay policy compliance
- playsinline prevents iOS Safari from going fullscreen
- Users can no longer pause/seek gallery videos — intentional per Gio (GIF-like behavior)
- On slow connections there is a brief black rectangle before video loads (poster removed intentionally)
- JS .play().catch() fallback added to match the hero reel pattern for mobile reliability