### PR TITLE
Fix mobile scroll — smooth scrolling through portfolio and homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -93,8 +93,8 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 
 .reel{position:relative;width:100%;height:100vh;overflow:hidden;background:#000}
 
-.rslides{display:flex;height:100%;transition:transform .9s cubic-bezier(.77,0,.18,1)}
-.rslide{min-width:100%;height:100%;position:relative;flex-shrink:0;overflow:hidden}
+.rslides{display:flex;height:100%;transition:transform .9s cubic-bezier(.77,0,.18,1);touch-action:pan-y}
+.rslide{min-width:100%;height:100%;position:relative;flex-shrink:0;overflow:hidden;touch-action:pan-y}
 .rslide video{width:100%;height:100%;object-fit:cover;display:block}
 .rslide .vfb{width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-family:var(--fe);font-size:6rem;font-weight:800;letter-spacing:.04em;color:rgba(238,235,229,.03)}
 .fb1{background:linear-gradient(135deg,#030d0b,#071a14,#0a241c)}
@@ -280,8 +280,8 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 @keyframes fb-pulse-white{0%,100%{box-shadow:0 0 0 0 rgba(238,235,229,0)}50%{box-shadow:0 0 8px 2px rgba(238,235,229,.3)}}
 
 /* Portfolio grid */
-.pgrid{padding:.5rem 0 6rem;display:grid;grid-template-columns:repeat(6,1fr);gap:3px}
-.pcard{position:relative;overflow:hidden;background:var(--surf);cursor:none;display:block;aspect-ratio:1/1}
+.pgrid{padding:.5rem 0 6rem;display:grid;grid-template-columns:repeat(6,1fr);gap:3px;touch-action:pan-y}
+.pcard{position:relative;overflow:hidden;background:var(--surf);cursor:none;display:block;aspect-ratio:1/1;touch-action:pan-y}
 .pcard img.thumb{width:100%;height:100%;display:block;object-fit:cover;transition:transform .55s cubic-bezier(.25,.46,.45,.94)}
 .pcard:hover img.thumb{transform:scale(1.04)}
 .pcard-ov{position:absolute;inset:0;background:linear-gradient(to top,rgba(13,13,14,.95) 0%,rgba(13,13,14,.3) 45%,transparent 70%);opacity:0;transition:opacity .35s;display:flex;flex-direction:column;justify-content:flex-end;padding:1.2rem}
@@ -2671,8 +2671,12 @@ window.addEventListener('scroll',()=>{
 })();
 
 // touch: first tap reveals overlay, second tap opens post
-let lastCard=null;
-document.addEventListener('touchstart',function(e){
+// uses touchend + scroll-detection so vertical scrolling is never blocked
+let lastCard=null,tStartY=0,tDidScroll=false;
+document.addEventListener('touchstart',function(e){tStartY=e.touches[0]?.clientY||0;tDidScroll=false;},{passive:true});
+document.addEventListener('touchmove',function(e){if(Math.abs((e.touches[0]?.clientY||0)-tStartY)>8)tDidScroll=true;},{passive:true});
+document.addEventListener('touchend',function(e){
+  if(tDidScroll)return;
   const card=e.target.closest('.pcard');
   if(!card)return;
   const ov=card.querySelector('.pcard-ov');


### PR DESCRIPTION
## What Giovanni Asked For
Smooth scrolling on mobile — portfolio cards and homepage reel were blocking vertical scroll.

## What Changed
- Portfolio card tap handler switched from touchstart+preventDefault to touchend+scroll detection, so vertical scrolling is never blocked
- Added touch-action:pan-y CSS to reel slides, portfolio grid, and cards to eliminate scroll hesitation
- Scroll detection uses 8px threshold to distinguish taps from scrolls

## Files Modified
- public/index.html — CSS touch-action additions, JS touch handler rewrite

## How to Verify
1. Open the Vercel preview URL on a mobile device (or Chrome DevTools mobile emulation)
2. Scroll through the portfolio grid — should be smooth with no delay
3. Scroll the homepage hero reel into content — no hesitation
4. Tap portfolio cards — first tap shows overlay, second tap opens project

## Risk Level
High — JS logic changes to touch event handlers

## Notes for Jonny
- Replaces passive:false touchstart (which blocked all scrolling) with passive:true touchstart/touchmove + passive:false touchend
- Two-tap flow preserved: preventDefault on touchend suppresses synthetic click per W3C Touch Events spec
- touch-action:pan-y tells browser to commit to vertical scroll immediately
- Worth testing on real iOS Safari to confirm two-tap behavior