### PR TITLE
Make all software logos white — Skills section and project posts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -244,9 +244,9 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .recgrid .rc:nth-last-child(2){border-bottom-left-radius:10px}
 .recgrid .rc:last-child{border-bottom-right-radius:10px}
 /* rec cards are now <a> tags — reset link styles */
-.rc{background:var(--surf);padding:1.8rem;display:block;text-decoration:none;color:inherit;transition:background .2s,box-shadow .2s}
+.rc{background:var(--surf);padding:1.8rem;display:flex;flex-direction:column;justify-content:space-between;text-decoration:none;color:inherit;transition:background .2s,box-shadow .2s}
 .rc:hover{background:#1c1c1f;box-shadow:inset 0 0 0 1px var(--acc)}
-.rq{font-size:.82rem;line-height:1.82;color:#8e8a84;font-style:italic;font-weight:300;margin-bottom:1.3rem;padding-left:.9rem;border-left:2px solid var(--acc)}
+.rq{font-size:.82rem;line-height:1.82;color:#8e8a84;font-style:italic;font-weight:300;margin-bottom:1.8rem;padding-left:.9rem;border-left:2px solid var(--acc)}
 .rp{display:flex;align-items:center;gap:.8rem}
 .rp img{width:40px;height:40px;border-radius:50%;object-fit:cover;border:1px solid var(--brd2);flex-shrink:0}
 .rn{font-size:.8rem;font-weight:500;display:flex;align-items:center;gap:.3rem}

--- a/public/index.html
+++ b/public/index.html
@@ -1867,7 +1867,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — Spaceship',
     tagline:'Vehicle · Cinder Interactive · UE5',
     tags:[['Vehicle','h'],['UE5','h'],['Low Poly',''],['PBR',''],['Maya',''],['Substance Painter','']],
-    desc:`<p>Giovanni crafted a futuristic spaceship, optimized for optimal in-game performance. Inspired by the Star Wars and Porsche collab project, this low-poly 3D model boasts striking design and meticulous detail.</p><p>3D environment artist Edward Rosen executed the level design and art for the map.</p>`,
+    desc:`<p>Giovanni built a futuristic spaceship for the Space Station level, inspired by the Star Wars × Porsche collaboration. Kept low-poly and game-ready.</p><p>Level design and art by Edward Rosen.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind',year:'2020',engine:'Unreal Engine 5',
     sw:['Maya','Substance Painter','Marmoset Toolbag','UE5'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -1901,7 +1901,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — Helicopter',
     tagline:'Vehicle · Cinder Interactive · UE5',
     tags:[['Vehicle','h'],['Art Test','h'],['Maya',''],['Substance Painter',''],['Game Ready',''],['Cinder Interactive','']],
-    desc:`<p>Giovanni's first prop test — a meticulously crafted military helicopter — secured his place on Cinder Interactive. Built with attention to detail and optimized to be game ready.</p><p>Giovanni embraced feedback, defended his work with reference images when needed, and fostered a collaborative environment that facilitated learning and knowledge sharing.</p>`,
+    desc:`<p>The prop test that got Giovanni onto Cinder Interactive. A military helicopter built to game-ready standard, with attention to detail throughout.</p><p>He pushed back on feedback with reference images when needed and was open to critique from the team.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind',year:'2020',engine:'Unreal Engine 5',
     sw:['Maya','Substance Painter','Marmoset Toolbag'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -1961,7 +1961,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — Airplane',
     tagline:'Vehicle · Cinder Interactive · UE5',
     tags:[['Vehicle','h'],['Redesign','h'],['Cinder Interactive',''],['Maya',''],['Substance Painter',''],['UE5','']],
-    desc:`<p>Giovanni redesigned the airplane for TimeSplitters' Hangar level, highlighting his skill in 3D modeling and design, as well as his talent for revitalizing old assets with a fresh perspective.</p>`,
+    desc:`<p>Giovanni redesigned the airplane for the Hangar level, rebuilding an older asset to current-gen standard.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind',year:'2022',engine:'Unreal Engine 5',
     sw:['Maya','Substance Painter','UE5'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -1996,7 +1996,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — Carousel',
     tagline:'Hero Prop · Circus Level · Cinder Interactive',
     tags:[['Prop','h'],['Hero Asset','h'],['Circus Level',''],['Maya',''],['Substance Painter',''],['UE5','']],
-    desc:`<p>Giovanni crafted the carousel hero prop for the circus level in TimeSplitters: Rewind, while the level design and art were skillfully executed by Edward Rosen.</p>`,
+    desc:`<p>Giovanni built the carousel hero prop for the Circus level. Level design and art by Edward Rosen.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind',year:'2022',engine:'Unreal Engine 5',
     sw:['Maya','Substance Painter','UE5'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -2032,7 +2032,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — Crane',
     tagline:'Prop · Docks Level · Cinder Interactive',
     tags:[['Prop','h'],['Redesign','h'],['Optimisation',''],['Ngon Fix',''],['Maya',''],['UE5','']],
-    desc:`<p>Giovanni refined the design of the crane for the Docks level that was originally from another 3D artist's art test, by addressing Ngons and wireframe issues. He substantially reduced the polycount while implementing crucial redesigns for improved performance and respecting the original level design's block out.</p>`,
+    desc:`<p>Giovanni took over a crane originally from another artist's test piece for the Docks level. He fixed Ngons and wireframe issues, cut the polycount significantly, and reworked parts of the design while staying true to the original blockout.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind — Docks',year:'2022',engine:'Unreal Engine 5',
     sw:['Maya','Substance Painter','UE5'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -2066,7 +2066,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — Bulletproof Pickup',
     tagline:'Pickup Prop · Cinder Interactive · UE5',
     tags:[['Pickup Prop','h'],['Current Gen','h'],['Game Ready',''],['Low Poly',''],['Maya',''],['Substance Painter','']],
-    desc:`<p>Giovanni revamped the Bulletproof Pickup asset for TimeSplitters: Rewind, updating its design for the current generation. This optimized, low-poly 3D model is game-ready with excellent edge flow, ensuring top performance while keeping a modern contemporary look.</p>`,
+    desc:`<p>Giovanni updated the Bulletproof Pickup for current-gen, reworking the design while keeping it low-poly and game-ready with clean edge flow.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind',year:'2023',engine:'Unreal Engine 5',
     sw:['Maya','Substance Painter','UE5'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -2159,7 +2159,7 @@ const POSTS={
     title:'BMW S1000RR — Motorcycle',
     tagline:'Personal Portfolio · Vehicle · Hard Surface',
     tags:[['Personal Project','h'],['Vehicle','h'],['Hard Surface',''],['Maya',''],['Substance Painter',''],['Marmoset Toolbag','']],
-    desc:`<p>As a compelling side project for his portfolio, Giovanni embraced the challenge of creating his first 3D motorcycle model, inspired by Edgar Heinrich's intriguing asymmetrical design. This project marked significant improvements over his previous Nissan Skyline model and offered valuable learning experiences. Giovanni looks forward to applying the insights gained from this endeavor to future models.</p>`,
+    desc:`<p>A personal portfolio project. Giovanni's first 3D motorcycle, inspired by Edgar Heinrich's asymmetrical design. A noticeable step up from his previous Nissan Skyline model, with a lot learned along the way.</p>`,
     studio:'Personal',project:'Portfolio Piece',year:'2023',engine:'Marmoset Toolbag',
     sw:['Maya','Substance Painter','Marmoset Toolbag 3','Photoshop'],
     images:[
@@ -2185,7 +2185,7 @@ const POSTS={
     title:'Grab a Duck — Award Winning Student Game',
     tagline:'Game · Dead Salmon · Unity · 4-Week Sprint',
     tags:[['Best Student Game','h'],['Team Project','h'],['Maya',''],['Substance Painter',''],['Unity',''],['4-Week Sprint','']],
-    desc:`<p>Giovanni played a key role in the creation of 'Grab a Duck,' a multiplayer bathtub-themed game developed in just four weeks by Dead Salmon, a dynamic team of two engineers and four designers. The game won the Best First-Year Game award at the Heim Museum in Hengelo, The Netherlands.</p><p>Giovanni was responsible for 3D modelling and texturing assets for Grab a Duck.</p>`,
+    desc:`<p>Giovanni was part of Dead Salmon, a six-person student team who built 'Grab a Duck' in four weeks. A multiplayer bathtub game that won the Best First-Year Game at the Heim Museum in Hengelo, The Netherlands.</p><p>He handled all 3D modelling and texturing for the game.</p>`,
     studio:'Dead Salmon (Saxion University)',project:'Grab a Duck',year:'2020',engine:'Unity',
     sw:['Maya','Substance Painter','Unity','Photoshop'],
     images:[
@@ -2239,7 +2239,7 @@ const POSTS={
     title:"Witch's Den — Beyond Extent Team Challenge",
     tagline:'Environment Art · Beyond Extent · Team Project',
     tags:[['Environment Art','h'],['Beyond Extent','h'],['Hero Prop',''],['Skulls',''],['Voodoo Decals',''],['UE5','']],
-    desc:`<p>I recently took part in the Witches' Den team challenge with Beyond Extent. Over the course of five weeks, our team of five artists planned, developed, and produced a full set of 3D game-ready assets to bring this environment to life.</p><p>Working with the team was an incredibly rewarding experience, and I'm really proud of what we achieved together. My contributions included creating a hero prop (a boat), sculpting and modelling skull assets, high poly to low poly baking, producing Voodoo veve alphas for decal texturing, and collaborating on the overall level design from the initial blockout all the way to the final result.</p><p>Be sure to check out the amazing work from the rest of the team:<br>
+    desc:`<p>I recently took part in the Witches' Den team challenge with Beyond Extent. Over the course of five weeks, our team of five artists planned, developed, and produced a full set of 3D game-ready assets to bring this environment to life.</p><p>Working with the team was great, and I'm proud of what we built together. My contributions included creating a hero prop (a boat), sculpting and modelling skull assets, high poly to low poly baking, producing Voodoo veve alphas for decal texturing, and collaborating on the overall level design from the initial blockout all the way to the final result.</p><p>Be sure to check out the amazing work from the rest of the team:<br>
       <a href="https://www.artstation.com/jackshergold" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Jack Shergold</a> ·
       <a href="https://www.artstation.com/joebates1" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Joe Bates</a> ·
       <a href="https://www.artstation.com/danielkent8" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Daniel Kent</a> ·
@@ -2475,7 +2475,7 @@ function showPost(id){
   if(p.tsUrl){
     dlWrap.innerHTML=`<a href="${p.tsUrl}" target="_blank" rel="noopener noreferrer" class="ts-dl-btn">
       <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-      Download TimeSplitters: Rewind — Free
+      Download TimeSplitters: Rewind · Free
     </a>
     <div class="ts-dl-sub">Free to play · Largest free-content game ever made</div>
     <div class="ts-dl-date"><span class="ts-dl-date-label">Release Date</span> Nov 23, 2025</div>`;

--- a/public/index.html
+++ b/public/index.html
@@ -213,6 +213,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .lp.nat{border-color:var(--acc);color:var(--acc)}
 .skgrid{display:grid;grid-template-columns:1fr 1fr}
 .ski{display:inline-flex;align-items:center;gap:.32rem;font-size:.58rem;letter-spacing:.05em;padding:.24rem .55rem;background:var(--surf2);border:1px solid var(--brd);color:var(--mut);font-family:var(--fm);border-radius:9999px}
+.ski img,.sw img{filter:brightness(0) invert(1)}
 
 /* ── HOME: work strip ── */
 .wstrip{padding:0 2.5rem 4rem;max-width:1280px;margin:0 auto}

--- a/public/index.html
+++ b/public/index.html
@@ -2184,7 +2184,7 @@ const POSTS={
     thumb:B+'2026/03/grabaduck-thumbnail.webp',
     title:'Grab a Duck — Award Winning Student Game',
     tagline:'Game · Dead Salmon · Unity · 4-Week Sprint',
-    tags:[['🏆 Best Student Game','h'],['Team Project','h'],['Maya',''],['Substance Painter',''],['Unity',''],['4-Week Sprint','']],
+    tags:[['Best Student Game','h'],['Team Project','h'],['Maya',''],['Substance Painter',''],['Unity',''],['4-Week Sprint','']],
     desc:`<p>Giovanni played a key role in the creation of 'Grab a Duck,' a multiplayer bathtub-themed game developed in just four weeks by Dead Salmon, a dynamic team of two engineers and four designers. The game won the Best First-Year Game award at the Heim Museum in Hengelo, The Netherlands.</p><p>Giovanni was responsible for 3D modelling and texturing assets for Grab a Duck.</p>`,
     studio:'Dead Salmon (Saxion University)',project:'Grab a Duck',year:'2020',engine:'Unity',
     sw:['Maya','Substance Painter','Unity','Photoshop'],

--- a/public/index.html
+++ b/public/index.html
@@ -1150,7 +1150,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         </div>
         <div class="skill-cat">
           <div class="skill-cat-label">Texturing</div>
-          <div class="skill-cat-items"><span class="ski"><img src="/wp-content/uploads/2026/10/substance-color.svg" width="14" height="14" style="flex-shrink:0" alt="">Substance Painter</span><span class="ski"><img src="/wp-content/uploads/2026/10/substance-color.svg" width="14" height="14" style="flex-shrink:0" alt="">Substance Designer</span><span class="ski"><img src="/wp-content/uploads/2026/10/photoshop-color.svg" width="14" height="14" style="flex-shrink:0" alt="">Photoshop</span></div>
+          <div class="skill-cat-items"><span class="ski"><img src="/wp-content/uploads/2026/10/substance-color.svg" width="14" height="14" style="flex-shrink:0" alt="">Substance Painter</span><span class="ski"><img src="/wp-content/uploads/2026/10/substance-color.svg" width="14" height="14" style="flex-shrink:0" alt="">Substance Designer</span><span class="ski"><img src="/wp-content/uploads/2026/10/photoshop.svg" width="14" height="14" style="flex-shrink:0" alt="">Photoshop</span></div>
         </div>
         <div class="skill-cat">
           <div class="skill-cat-label">Real-time & Rendering</div>
@@ -1811,7 +1811,7 @@ const SW_ICONS={
   'Substance Painter':'<img src="/wp-content/uploads/2026/10/substance-color.svg" width="13" height="13" style="opacity:1;flex-shrink:0;vertical-align:middle" alt="">',
   'Marmoset Toolbag':'<img src="/wp-content/uploads/2026/10/marmoset-toolbag.png" width="13" height="13" style="opacity:1;flex-shrink:0;vertical-align:middle" alt="">',
   'Marmoset Toolbag 3':'<img src="/wp-content/uploads/2026/10/marmoset-toolbag.png" width="13" height="13" style="opacity:1;flex-shrink:0;vertical-align:middle" alt="">',
-  'Photoshop':'<img src="/wp-content/uploads/2026/10/photoshop-color.svg" width="13" height="13" style="opacity:1;flex-shrink:0;vertical-align:middle" alt="">',
+  'Photoshop':'<img src="/wp-content/uploads/2026/10/photoshop.svg" width="13" height="13" style="opacity:1;flex-shrink:0;vertical-align:middle" alt="">',
   'VRay':'<img src="/wp-content/uploads/2026/10/vray-color.svg" width="13" height="13" style="opacity:1;flex-shrink:0;vertical-align:middle" alt="">',
 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -1133,7 +1133,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
       <h2>CRAFTING WORLDS,<br>ONE POLYGON AT A TIME</h2>
       <p>3D artist with a Bachelor's in Creative Media and Game Technologies from Saxion. I build assets and environments that make game worlds feel like real places.</p>
       <p>On TimeSplitters: Rewind with Cinder Interactive since 2020, shipping props, vehicles, and character assets for the largest free-content game ever made. Working under Cameron Williams (ex-Rockstar, Infinity Ward) and Samuel Freeman (Splash Damage) has pushed my craft in ways no school could.</p>
-      <p>I take feedback well, work well in a team, and I'm always looking at what I can do better.</p>
+      <p>I take critique seriously, work closely with teams, and am always pushing the quality of my work.</p>
       <div class="langs">
         <span class="lp nat">English — Native</span>
         <span class="lp nat">Papiamentu — Native</span>
@@ -1216,7 +1216,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
           <ul class="wlist">
             <li>Built props, vehicles, and character assets for TimeSplitters: Rewind, staying true to the original game's art direction.</li>
             <li>Modeled, UV unwrapped, and baked high-to-low poly assets from brief to QA sign-off.</li>
-            <li>Contributed to pipeline documentation to keep art direction consistent across the team.</li>
+            <li>Wrote pipeline documentation to keep art direction consistent across the team.</li>
             <li>Tracked tasks and milestones in Trello and HackNPlan within a Scrum workflow.</li>
           </ul>
         </div>
@@ -1292,7 +1292,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         <div class="winfo">
           <div class="wt">"Grab a Duck" — Best Student First Year Game <span class="wlink">↗</span></div>
           <div class="wd">Public Choice Award · Hengelo Heim Exhibition</div>
-          <div class="wdsc">Won the public choice award at the Heim Museum in Hengelo, The Netherlands. Responsible for all 3D modelling and texturing for the game's assets.</div>
+          <div class="wdsc">Won the public choice award at the Heim Museum, Hengelo, Netherlands. Built and textured all 3D assets for the game.</div>
         </div>
       </a>
     </div>
@@ -1828,7 +1828,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — Turret',
     tagline:'Prop · Cinder Interactive · UE5',
     tags:[['Prop','h'],['Current Gen','h'],['ZBrush',''],['PBR Texturing',''],['Maya',''],['Normals Bake','']],
-    desc:`<p>Giovanni improved and reimagined the Turret asset for Rewind, enhancing its design for the current generation remake. With freedom from the technical constraints of the original, he added extra details to bring it up to modern standards.</p><p>Giovanni also maintained a low poly wireframe for optimal performance while maintaining as much of the visual fidelity as possible through usage of normals and PBR textures.</p>`,
+    desc:`<p>Giovanni redesigned the Turret for Rewind's current-gen remake. Free from the technical limits of the original, he pushed the detail further while keeping the polycount low — preserving visual fidelity through normals and PBR textures.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind',year:'2021',engine:'Unreal Engine 5',
     sw:['Maya','ZBrush','Substance Painter','Marmoset Toolbag','UE5'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -1932,7 +1932,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — The Impersonator',
     tagline:'Character · Cinder Interactive · UE5',
     tags:[['Character','h'],['ZBrush','h'],['Retopology',''],['UV Mapping',''],['Substance Painter',''],['Maya','']],
-    desc:`<p>Giovanni assisted a character artist who was experiencing burnout by completing their high poly model in ZBrush, followed by retopologizing and UV mapping it in Autodesk Maya, and ultimately texturing it in Substance Painter.</p><p>Giovanni was guided through this process by lead character artist Samuel Freeman.</p>`,
+    desc:`<p>A character artist on the team was burning out, so Giovanni stepped in to finish their high poly in ZBrush, retopo and UV in Maya, then texture in Substance Painter.</p><p>Lead character artist Samuel Freeman guided him through the process.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind',year:'2022',engine:'Unreal Engine 5',
     sw:['ZBrush','Maya','Substance Painter','Marmoset Toolbag'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -2101,7 +2101,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — Cryogen Case',
     tagline:'Prop · Planet X Level · Cinder Interactive',
     tags:[['Prop','h'],['Hi→Lo Bake','h'],['Planet X',''],['ZBrush',''],['Maya',''],['Substance Painter','']],
-    desc:`<p>Giovanni created the Cryogen Case with the Human Brain as a gaming-ready 3D asset prop for the Planet X level in TimeSplitters. He efficiently preserved the low poly count by baking information from the high poly brain onto the low poly model using normals in Substance Painter.</p>`,
+    desc:`<p>Giovanni built the Cryogen Case and Human Brain prop for the Planet X level in TimeSplitters. He kept the polycount low by baking the high poly brain detail into normals in Substance Painter.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind — Planet X',year:'2023',engine:'Unreal Engine 5',
     sw:['Maya','ZBrush','Substance Painter','Marmoset Toolbag'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -2130,7 +2130,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — The Shoal',
     tagline:'Character · Cinder Interactive · UE5',
     tags:[['Character','h'],['Unique Design','h'],['ZBrush',''],['Maya',''],['Substance Painter',''],['UE5','']],
-    desc:`<p>The Shoal is a group of fish surrounding a large whale, wearing a black top hat and smoking a pipe. Instead of arms, he uses smaller fish to wield and fire weapons. He's one of the unique floating characters in TimeSplitters.</p>`,
+    desc:`<p>The Shoal is a group of fish orbiting a large whale in a black top hat, pipe in hand. Instead of arms, he wields weapons using smaller fish. One of TimeSplitters' most distinctive characters.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind',year:'2023',engine:'Unreal Engine 5',
     sw:['ZBrush','Maya','Substance Painter','UE5'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -2213,7 +2213,7 @@ const POSTS={
     title:'Rituals Cosmetics — Product CGI',
     tagline:'Commercial CGI · Lukkien · VRay',
     tags:[['Commercial CGI','h'],['Lukkien','h'],['3DS Max',''],['VRay',''],['Photorealistic',''],['NDA','']],
-    desc:`<p>During his time at Lukkien (Aug 2022 – Dec 2024), Giovanni contributed to photorealistic 1:1 CGI renders of Rituals cosmetics products for use on the brand's website and marketing materials. Work covered modelling, UV mapping, custom shader networks, texturing, and rendering across a wide range of product lines. NDA restrictions limit what can be shown publicly.</p>`,
+    desc:`<p>During his time at Lukkien (Aug 2022 – Dec 2024), Giovanni produced photorealistic 1:1 CGI renders of Rituals cosmetics products for the brand's website and marketing. Work spanned modelling, UV mapping, custom shader networks, texturing, and rendering across multiple product lines. NDA restrictions limit what can be shown publicly.</p>`,
     studio:'Lukkien',project:'Rituals Cosmetics',year:'2022–2024',engine:'3DS Max + VRay',
     sw:['3DS Max','VRay','Photoshop','Asana'],
     images:[
@@ -2239,7 +2239,7 @@ const POSTS={
     title:"Witch's Den — Beyond Extent Team Challenge",
     tagline:'Environment Art · Beyond Extent · Team Project',
     tags:[['Environment Art','h'],['Beyond Extent','h'],['Hero Prop',''],['Skulls',''],['Voodoo Decals',''],['UE5','']],
-    desc:`<p>I recently took part in the Witches' Den team challenge with Beyond Extent. Over the course of five weeks, our team of five artists planned, developed, and produced a full set of 3D game-ready assets to bring this environment to life.</p><p>Working with the team was great, and I'm proud of what we built together. My contributions included creating a hero prop (a boat), sculpting and modelling skull assets, high poly to low poly baking, producing Voodoo veve alphas for decal texturing, and collaborating on the overall level design from the initial blockout all the way to the final result.</p><p>Be sure to check out the amazing work from the rest of the team:<br>
+    desc:`<p>I took part in the Witch's Den team challenge with Beyond Extent. Over five weeks, a team of five artists planned, built, and delivered a complete set of game-ready 3D assets for this environment.</p><p>Working with the team was a great experience, and I'm proud of what we built. My work included the hero prop (a boat), sculpted skull assets, high-to-low poly baking, Voodoo veve alphas for decal texturing, and level design from blockout to final polish.</p><p>Be sure to check out the amazing work from the rest of the team:<br>
       <a href="https://www.artstation.com/jackshergold" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Jack Shergold</a> ·
       <a href="https://www.artstation.com/joebates1" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Joe Bates</a> ·
       <a href="https://www.artstation.com/danielkent8" target="_blank" rel="noopener noreferrer" style="color:var(--acc)">Daniel Kent</a> ·

--- a/public/index.html
+++ b/public/index.html
@@ -1182,22 +1182,22 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
       <div class="spec-card">
         <div class="spec-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" style="fill:#0eb8a0;stroke:none"><path d="M 11.5 7 C 8.4802259 7 6 9.4802259 6 12.5 L 6 31.476562 C 6 32.934359 6.5784179 34.334277 7.609375 35.365234 L 13.390625 41.148438 A 1.5005306 1.5005306 0 0 0 13.425781 41.179688 C 14.432944 42.293729 15.883249 43 17.5 43 L 31.058594 43 C 30.549594 42.503 30.188641 41.854953 30.056641 41.126953 L 29.851562 40 L 17.5 40 C 16.122 40 15 38.878 15 37.5 L 15 16 L 36.5 16 C 37.878 16 39 17.122 39 18.5 L 39 30.898438 L 42 33.232422 L 42 18.5 C 42 16.888719 41.29889 15.442325 40.191406 14.435547 A 1.5005306 1.5005306 0 0 0 40.148438 14.390625 L 34.365234 8.609375 C 33.333806 7.5779465 31.933733 7 30.476562 7 L 11.5 7 z M 11.5 10 L 30.476562 10 C 31.139394 10 31.775569 10.26385 32.244141 10.732422 L 34.511719 13 L 14.5 13 C 14.382479 13 14.26951 13.019372 14.15625 13.035156 L 11.230469 10.109375 C 11.33281 10.097037 11.393892 10 11.5 10 z M 9.109375 12.230469 L 12.035156 15.15625 C 12.019372 15.26951 12 15.382479 12 15.5 L 12 35.511719 L 9.7324219 33.244141 C 9.263379 32.775098 9 32.140767 9 31.476562 L 9 12.5 C 9 12.393892 9.097037 12.33281 9.109375 12.230469 z M 31.587891 28.001953 C 31.291141 27.984828 30.988156 28.056297 30.722656 28.216797 C 30.190656 28.538797 29.913391 29.155578 30.025391 29.767578 L 32.025391 40.767578 C 32.137391 41.384578 32.622234 41.868563 33.240234 41.976562 C 33.327234 41.993563 33.414 42 33.5 42 C 34.026 42 34.522922 41.723813 34.794922 41.257812 L 35.857422 39.441406 L 38.222656 43.285156 A 1.50015 1.50015 0 1 0 40.777344 41.714844 L 38.503906 38.019531 L 40.515625 38 C 41.153625 37.994 41.717875 37.583516 41.921875 36.978516 C 42.125875 36.373516 41.924875 35.708406 41.421875 35.316406 L 32.421875 28.316406 C 32.176375 28.125406 31.884641 28.019078 31.587891 28.001953 z"/></svg></div>
         <div class="spec-name">Hard Surface Modeling</div>
-        <div class="spec-desc">Vehicles, weapons, props, and mechanical assets. Game-ready meshes with clean topology — shipped on TimeSplitters: Rewind.</div>
+        <div class="spec-desc">Vehicles, weapons, props, and mechanical assets. Game-ready meshes with clean topology, shipped on TimeSplitters: Rewind.</div>
       </div>
       <div class="spec-card">
         <div class="spec-icon"><svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg></div>
         <div class="spec-name">UV Mapping & Normal Baking</div>
-        <div class="spec-desc">UV layouts that get the most out of each texture sheet. Solid high-to-low bakes, no shortcuts — applied across the full TimeSplitters prop library.</div>
+        <div class="spec-desc">UV layouts that get the most out of each texture sheet. Solid high-to-low bakes with no shortcuts, applied across the full TimeSplitters prop library.</div>
       </div>
       <div class="spec-card">
         <div class="spec-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 12 12 17 22 12"/><polyline points="2 17 12 22 22 17"/></svg></div>
         <div class="spec-name">PBR Texturing</div>
-        <div class="spec-desc">PBR materials in Substance Painter and Designer. Metal, wear, grime, aged surfaces — seen in the Witch's Den environment and Cryogen Case.</div>
+        <div class="spec-desc">PBR materials in Substance Painter and Designer. Metal, wear, grime, aged surfaces. Seen in the Witch's Den environment and Cryogen Case.</div>
       </div>
       <div class="spec-card">
         <div class="spec-icon"><svg viewBox="0 0 512 512" style="fill:#0eb8a0;stroke:none"><g><path d="m361.5 18.343h30v30h-30z"/><path d="m361.5 167.093h30v30h-30z"/><path d="m435.875 92.718h30v30h-30z"/><path d="m287.125 92.718h30v30h-30z"/><path d="m308.909 40.127h30v30h-30z" transform="matrix(.707 -.707 .707 .707 55.89 245.185)"/><path d="m414.091 145.31h30v30h-30z" transform="matrix(.707 -.707 .707 .707 12.324 350.371)"/><path d="m414.091 40.127h30v30h-30z" transform="matrix(.707 -.707 .707 .707 86.694 319.556)"/><path d="m308.909 145.309h30v30h-30z" transform="matrix(.707 -.707 .707 .707 -18.486 275.988)"/><circle cx="376.5" cy="107.718" r="39.906"/><path d="m160.27 336.643c10.828-16.246 28.948-25.944 48.47-25.944s37.642 9.699 48.47 25.944l51.996 78.015h79.425l-156.383-234.638c-5.25-7.878-14.038-12.582-23.506-12.582s-18.255 4.704-23.506 12.582l-156.383 234.637h79.422z"/><path d="m492.003 414.657-106.114-159.213c-7.407-11.113-19.878-17.789-33.233-17.789s-25.827 6.676-33.234 17.789l-.426.64 105.687 158.573z"/><path d="m208.74 340.698c-9.468 0-18.255 4.704-23.507 12.583l-40.906 61.376h128.827l-40.907-61.376c-5.251-7.879-14.039-12.583-23.507-12.583z"/><path d="m0 444.657h512v49h-512z"/></g></svg></div>
         <div class="spec-name">Environment Art</div>
-        <div class="spec-desc">Modular sets, props, and environmental dressing. Architecture and organic forms built to fill a scene — showcased in the Witch's Den project.</div>
+        <div class="spec-desc">Modular sets, props, and environmental dressing. Architecture and organic forms built to fill a scene, seen in the Witch's Den project.</div>
       </div>
     </div>
   </div>
@@ -1211,7 +1211,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         <div class="wlogo"><img src="/wp-content/uploads/2024/07/Cinder.webp" alt="Cinder Interactive" loading="lazy" decoding="async" style="max-height:64px;max-width:72px"></div>
         <div class="wdiv"></div>
         <div class="winfo">
-          <div class="wt">3D Artist — Cinder Interactive <span class="wlink">↗</span></div>
+          <div class="wt">3D Artist · Cinder Interactive <span class="wlink">↗</span></div>
           <div class="wd">Jan 2020 – Present · USA, Remotely from NL</div>
           <ul class="wlist">
             <li>Built props, vehicles, and character assets for TimeSplitters: Rewind, staying true to the original game's art direction.</li>
@@ -1226,7 +1226,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         <div class="wlogo" style="margin-top:24px"><img src="/wp-content/uploads/2024/07/LUKKIEN-1024x221.webp" alt="Lukkien" loading="lazy" decoding="async"></div>
         <div class="wdiv"></div>
         <div class="winfo">
-          <div class="wt">3D Artist — Lukkien <span class="wlink">↗</span></div>
+          <div class="wt">3D Artist · Lukkien <span class="wlink">↗</span></div>
           <div class="wd">Aug 2022 – Dec 2024 · Ede, Netherlands</div>
           <ul class="wlist">
             <li>Modeled product assets in 3DS Max for Rituals Cosmetics.</li>
@@ -1290,7 +1290,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         <div class="wlogo" style="width:72px;flex-shrink:0;display:flex;align-items:center;justify-content:center"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 42 42" style="fill:#999;stroke:none"><path d="M39,21c0-2.967-2.167-5.431-5-5.91V6.675c0-2.026-1.648-3.675-3.675-3.675H11.675c-2.026,0-3.675,1.649-3.675,3.675v28.649c0,2.026,1.648,3.675,3.675,3.675h18.65c2.026,0,3.675-1.649,3.675-3.675v-2.456l1.445.964c.167.112.36.168.555.168.162,0,.324-.039.472-.118.325-.174.528-.513.528-.882v-7.54c1.224-1.099,2-2.688,2-4.46ZM30.325,37H11.675c-.924,0-1.675-.751-1.675-1.675V6.675c0-.924.751-1.675,1.675-1.675h18.65c.924,0,1.675.751,1.675,1.675v8.415c-2.833.478-5,2.942-5,5.91,0,1.771.776,3.36,2,4.46v7.54c0,.369.203.708.528.882.324.173.72.154,1.026-.05l1.445-.964v2.456c0,.924-.751,1.675-1.675,1.675ZM35,31.131l-1.445-.963c-.336-.224-.773-.224-1.109,0l-1.445.963v-4.481c.627.223,1.298.35,2,.35s1.373-.128,2-.35v4.481ZM33,25c-2.206,0-4-1.794-4-4s1.794-4,4-4,4,1.794,4,4-1.794,4-4,4Z"/><path d="M14.643,14h12.715c.905,0,1.643-.737,1.643-1.643v-2.715c0-.906-.737-1.643-1.643-1.643h-12.715c-.905,0-1.643.737-1.643,1.643v2.715c0,.906.737,1.643,1.643,1.643ZM15,10h12v2h-12v-2Z"/><path d="M24,17h-10c-.553,0-1,.448-1,1s.447,1,1,1h10c.553,0,1-.448,1-1s-.447-1-1-1Z"/><path d="M24,22h-10c-.553,0-1,.448-1,1s.447,1,1,1h10c.553,0,1-.448,1-1s-.447-1-1-1Z"/><path d="M24,27h-10c-.553,0-1,.448-1,1s.447,1,1,1h10c.553,0,1-.448,1-1s-.447-1-1-1Z"/></svg></div>
         <div class="wdiv"></div>
         <div class="winfo">
-          <div class="wt">"Grab a Duck" — Best Student First Year Game <span class="wlink">↗</span></div>
+          <div class="wt">"Grab a Duck" · Best Student First Year Game <span class="wlink">↗</span></div>
           <div class="wd">Public Choice Award · Hengelo Heim Exhibition</div>
           <div class="wdsc">Won the public choice award at the Heim Museum, Hengelo, Netherlands. Built and textured all 3D assets for the game.</div>
         </div>
@@ -1828,7 +1828,7 @@ const POSTS={
     title:'TimeSplitters: Rewind — Turret',
     tagline:'Prop · Cinder Interactive · UE5',
     tags:[['Prop','h'],['Current Gen','h'],['ZBrush',''],['PBR Texturing',''],['Maya',''],['Normals Bake','']],
-    desc:`<p>Giovanni redesigned the Turret for Rewind's current-gen remake. Free from the technical limits of the original, he pushed the detail further while keeping the polycount low — preserving visual fidelity through normals and PBR textures.</p>`,
+    desc:`<p>Giovanni redesigned the Turret for Rewind's current-gen remake. Free from the technical limits of the original, he pushed the detail further while keeping the polycount low, preserving visual fidelity through normals and PBR textures.</p>`,
     studio:'Cinder Interactive',project:'TimeSplitters: Rewind',year:'2021',engine:'Unreal Engine 5',
     sw:['Maya','ZBrush','Substance Painter','Marmoset Toolbag','UE5'],
     tsUrl:'https://www.timesplittersrewind.com/',
@@ -1853,7 +1853,7 @@ const POSTS={
       {src:'4483efa1e6d14726902aa9a8e20d8b9b', type:'sketchfab', label:'Turret — Interactive 3D Model'},
     ],
     bd:[
-      {t:'Reference & Concept',b:'The original PS2-era Turret was analysed in depth. The goal was to feel unmistakably TimeSplitters while looking definitively current-gen — adding mechanical housing detail, panel seams, and surface wear impossible in the original.'},
+      {t:'Reference & Concept',b:'The original PS2-era Turret was analysed in depth. The goal was to feel unmistakably TimeSplitters while looking definitively current-gen: mechanical housing detail, panel seams, and surface wear impossible in the original.'},
       {t:'High Poly → Low Poly',b:'A detailed high poly sculpted in ZBrush served as the bake source. The game-ready low poly was built in Maya with clean topology, minimal Ngons, and sensible UV islands for maximum texel density.'},
       {t:'PBR Texturing',b:'Substance Painter materials captured industrial metal wear: chipped paint, oil staining around joint recesses, and battle scoring. Smart material layering kept the workflow efficient and maintainable.'},
       {t:'UE5 Integration',b:'Asset delivered to UE5 specification with LODs, collision meshes, and lightmap UVs. Nanite-compatible mesh for future scalability.'},
@@ -1888,7 +1888,7 @@ const POSTS={
     ],
     bd:[
       {t:'Design Language',b:'Inspired by the Star Wars × Porsche collaboration, the ship prioritises a sleek aerodynamic silhouette with purposeful panel breaks. Extensive reference gathering ensured cohesive proportions and believable surface logic.'},
-      {t:'Modelling & UVs',b:'Built in Autodesk Maya to a strict poly budget. UV layout maximised texel density on the cockpit and engine nacelles — the areas receiving most player attention during gameplay.'},
+      {t:'Modelling & UVs',b:'Built in Autodesk Maya to a strict poly budget. UV layout maximised texel density on the cockpit and engine nacelles, where players spend most of their time looking.'},
       {t:'PBR Texturing',b:'Full PBR suite in Substance Painter. Surface wear and panel-line reads built via procedural smart materials and hand-painted detail. Final presentation in Marmoset Toolbag.'},
       {t:'Engine Integration',b:'LODs, collision, and lightmap UVs authored for UE5 and delivered to Edward Rosen\'s level.'},
     ],
@@ -1921,7 +1921,7 @@ const POSTS={
       {t:'Art Test Brief',b:'The task was to create a game-ready military helicopter demonstrating modelling capability and a strong grasp of game asset pipelines. This test was the gateway to joining Cinder Interactive.'},
       {t:'Modelling',b:'Built in Maya from real-world reference. Careful attention to clean edge flow, no Ngons, and logical panel separation that reads well at all game draw distances.'},
       {t:'Texturing',b:'Full PBR in Substance Painter. Weathering, panel line grime, and directional scratching layered via smart materials and custom generators to give the asset battlefield-worn authenticity.'},
-      {t:'Collaboration',b:'Multiple review rounds with senior artists. Giovanni defended design choices with reference imagery while remaining fully receptive to critique — a dynamic that defined his approach throughout Cinder.'},
+      {t:'Collaboration',b:'Multiple review rounds with senior artists. Giovanni defended design choices with reference imagery while remaining fully receptive to critique, an approach that defined his work throughout Cinder.'},
     ],
     specs:{tris:'14,500',verts:'8,200',textures:'2K PBR · 4 maps (Albedo, Normal, ORM, Emissive)'},
     rel:['spaceship','airplane','turret']
@@ -1984,7 +1984,7 @@ const POSTS={
     bd:[
       {t:'Original Reference',b:'The TimeSplitters Hangar level airplane was a fan-recognisable asset. Extensive real-world military and civilian aircraft reference informed the surface detailing added to the current-gen version.'},
       {t:'Modelling',b:'Fuselage, wings, undercarriage, and engine nacelles constructed as separate mesh pieces in Maya for efficient LOD generation and modular reuse.'},
-      {t:'Texturing',b:'Aluminium skin, painted livery markings, window seals, and mechanical wear across the landing gear and engine areas — Substance Painter.'},
+      {t:'Texturing',b:'Aluminium skin, painted livery markings, window seals, and mechanical wear across the landing gear and engine areas. All in Substance Painter.'},
       {t:'Engine Integration',b:'Collision, LODs, and lightmap UVs set up to spec for the Hangar level layout in UE5.'},
     ],
     specs:{tris:'9,600',verts:'5,500',textures:'2K PBR · 4 maps (Albedo, Normal, ORM, Emissive)'},
@@ -2020,7 +2020,7 @@ const POSTS={
     bd:[
       {t:'Hero Prop Responsibility',b:'As the centrepiece of the circus level, the carousel received maximum attention to surface detail, material layering, and visual storytelling within the poly budget.'},
       {t:'Modelling',b:'Central pole, canopy, horses, decorative trim, and mechanical housing modelled as separate components in Maya for clean UVs and efficient LODs.'},
-      {t:'Materials',b:'Chipped painted metal, worn wood, faded fabric canopy, and metallic chrome trim — each material type authored in Substance Painter before final assembly.'},
+      {t:'Materials',b:'Chipped painted metal, worn wood, faded fabric canopy, and metallic chrome trim. Each material authored in Substance Painter before final assembly.'},
       {t:'Integration',b:'Asset handed to Edward Rosen\'s level build. Placement and lighting optimised so the carousel is the first thing the player\'s eye is drawn to on entering the map.'},
     ],
     specs:{tris:'18,200',verts:'10,300',textures:'2K PBR · 4 maps (Albedo, Normal, ORM, Emissive)'},
@@ -2088,7 +2088,7 @@ const POSTS={
     ],
     bd:[
       {t:'Design Intent',b:'A pickup needs to be instantly readable at distance by a player moving at speed. Clear silhouette and strong colour contrast ensure gameplay legibility.'},
-      {t:'Modelling',b:'Clean Maya mesh with excellent edge flow and zero Ngons. Polycount targeted for pickup prop spec — lighter than hero props while holding the key shape reads at every LOD.'},
+      {t:'Modelling',b:'Clean Maya mesh with excellent edge flow and zero Ngons. Polycount targeted for pickup prop spec, lighter than hero props while holding the key shape reads at every LOD.'},
       {t:'Texturing',b:'Substance Painter: military-grade wear, strap buckles, plate carrier texture variety. TimeSplitters pickup colour language preserved from the original.'},
       {t:'Current Gen',b:'Fabric weave normals, micro-surface roughness variation, and printed insignia added without losing the asset\'s iconic status.'},
     ],
@@ -2116,10 +2116,10 @@ const POSTS={
       {src:'/wp-content/uploads/2025/11/ken-levine-tweet.webp', fw:false, type:'img', label:'Ken Levine (BioShock) Tweet about TimeSplitters Rewind'},
     ],
     bd:[
-      {t:'Hard Surface — Case',b:'The cryogenic container was modelled in Maya with panel breaks, bolted flanges, and a transparent viewport panel — giving it a sci-fi medical read while keeping the mesh game-efficient.'},
+      {t:'Hard Surface — Case',b:'The cryogenic container was modelled in Maya with panel breaks, bolted flanges, and a transparent viewport panel, giving it a sci-fi medical read while keeping the mesh game-efficient.'},
       {t:'Organic — Brain',b:'The human brain was sculpted in ZBrush to a high level of anatomical detail: cortical folds, sulci, and brain stem all present. This high poly served purely as the bake source.'},
       {t:'Baking Workflow',b:'Normal, AO, and curvature maps baked from the ZBrush sculpt onto a low-poly mesh in Substance Painter. Polycount minimal while the normal map carries all organic complexity.'},
-      {t:'Texturing',b:'Metallic sci-fi container with frost edge wear. Brain textured as a preserved biological specimen — slightly discoloured, suspended in fluid suggested by the container\'s transparent panel.'},
+      {t:'Texturing',b:'Metallic sci-fi container with frost edge wear. Brain textured as a preserved biological specimen: slightly discoloured, suspended in fluid suggested by the container\'s transparent panel.'},
     ],
     specs:{tris:'4,200',verts:'2,200',textures:'2K PBR · 4 maps (Albedo, Normal, ORM, Emissive)'},
     rel:['turret','crane','bulletproof']
@@ -2148,7 +2148,7 @@ const POSTS={
       {t:'Absurdist Brief',b:'Realising the Shoal\'s cartoonish personality in current-gen fidelity without losing its iconic absurdist charm from the original TimeSplitters universe.'},
       {t:'Whale Body',b:'Sculpted in ZBrush to capture rounded, exaggerated proportions. Hard-surface top hat and pipe modelled in Maya and integrated into the organic body.'},
       {t:'Companion Fish',b:'A hero fish mesh instanced and varied in scale and pose to create the illusion of a dynamic school surrounding the main character.'},
-      {t:'Materials',b:'Slick cetacean skin, dapper hat fabric, worn pipe wood, and bright iridescent scales on the companion fish — each material reinforcing the character\'s comic personality.'},
+      {t:'Materials',b:'Slick cetacean skin, dapper hat fabric, worn pipe wood, and bright iridescent scales on the companion fish. Each material reinforces the character\'s comic personality.'},
     ],
     specs:{tris:'22,000',verts:'12,500',textures:'2K PBR · 4 maps (Albedo, Normal, ORM, Emissive)'},
     rel:['shoal','cryogen','turret']
@@ -2171,9 +2171,9 @@ const POSTS={
       {src:'0135f5871d1742499182d98c9218ed11', type:'sketchfab', label:'BMW S1000RR — Interactive 3D Model'},
     ],
     bd:[
-      {t:'Design Reference',b:'Edgar Heinrich\'s asymmetrical S1000RR — the iconic off-centre headlight and mixed fairing geometry — defined the modelling challenge. Extensive photo reference gathered before a single poly was placed.'},
+      {t:'Design Reference',b:'Edgar Heinrich\'s asymmetrical S1000RR, with its iconic off-centre headlight and mixed fairing geometry, defined the modelling challenge. Extensive photo reference gathered before a single poly was placed.'},
       {t:'Modelling Complexity',b:'Complex compound fairing curves that needed to flow seamlessly into each other presented the greatest challenge. Engine block, frame, and mechanical components tackled as separate objects before final assembly.'},
-      {t:'Texturing',b:'Painted carbon fibre fairings, brushed aluminium engine casings, rubber tyres, chrome exhaust, and matte plastic trim — all authored in Substance Painter.'},
+      {t:'Texturing',b:'Painted carbon fibre fairings, brushed aluminium engine casings, rubber tyres, chrome exhaust, and matte plastic trim. All authored in Substance Painter.'},
       {t:'Presentation',b:'Final renders in Marmoset Toolbag using a three-point studio rig. HDRI environment lighting supplemented key lights for convincing metallic reflections.'},
     ],
     specs:{tris:'13,200',verts:'7,600',textures:'2K PBR · 4 maps (Albedo, Normal, ORM, Roughness)'},
@@ -2198,10 +2198,10 @@ const POSTS={
     ],
     hasVideo:'/wp-content/uploads/2024/06/Grab-a-Duck-Trailer_1080p.mp4',
     bd:[
-      {t:'Scope & Timeline',b:'A full game asset list — environment, characters, and props — delivered in four weeks for Saxion University\'s first-year game project. Fast decision-making on art style and an efficient pipeline were critical.'},
+      {t:'Scope & Timeline',b:'A full game asset list (environment, characters, and props) delivered in four weeks for Saxion University\'s first-year game project. Fast decision-making on art style and an efficient pipeline were critical.'},
       {t:'Art Direction',b:'A clean, colourful toy-like aesthetic matching the light-hearted multiplayer concept. Low poly meshes with bold, saturated textures kept the art consistent and instantly readable in motion.'},
       {t:'3D Modelling',b:'All game assets modelled in Autodesk Maya. UV mapping handled alongside modelling to keep the pipeline moving at pace. Key assets: oversized bathtub environment, duck characters, pickup props.'},
-      {t:'Award',b:'Won the Public Choice Award for Best First-Year Game at the Hengelo Heim Museum Exhibition — recognising that the game was immediately enjoyable and visually appealing to a public audience.'},
+      {t:'Award',b:'Won the Public Choice Award for Best First-Year Game at the Hengelo Heim Museum Exhibition, voted by the public on the night.'},
     ],
     specs:{tris:'4,800',verts:'2,900',textures:'1K PBR · 3 maps (Albedo, Normal, ORM)'},
     rel:['motorcycle','turret','spaceship']
@@ -2226,9 +2226,9 @@ const POSTS={
     ],
     bd:[
       {t:'Modelling & UV Mapping',b:'Precise 1:1 modelling from physical product samples and engineering drawings. Maximum texel density for extremely close render distances.'},
-      {t:'Shader Networks',b:'Custom VRay material nodes for each product category — glass, translucent liquids, metallic caps, matte plastic bodies, and embossed label papers — all built for reuse across variants.'},
+      {t:'Shader Networks',b:'Custom VRay material nodes for each product category: glass, translucent liquids, metallic caps, matte plastic bodies, and embossed label papers. All built for reuse across variants.'},
       {t:'Label Texturing',b:'Rituals design team artwork integrated with careful attention to paper translucency, emboss depth, and print colour accuracy against the physical product.'},
-      {t:'Rendering',b:'Final renders in VRay for 3DS Max. Lighting tailored to each product\'s material characteristics — soft diffuse for matte cosmetics, sharper studio setups for metallic and glass.'},
+      {t:'Rendering',b:'Final renders in VRay for 3DS Max. Lighting tailored to each product\'s material characteristics: soft diffuse for matte cosmetics, sharper studio setups for metallic and glass.'},
     ],
     rel:['motorcycle','spaceship','turret']
   },
@@ -2288,7 +2288,7 @@ const POSTS={
     bd:[
       {t:'Hero Prop — The Boat',b:'The centrepiece prop for the environment was a weathered witchcraft boat, fully modelled and textured to hero-prop standard. It anchors the environment visually and communicates the narrative of the Witch\'s Den at a glance.'},
       {t:'Skull Assets',b:'Sculpted and modelled a set of skull props in ZBrush with full high-to-low poly baking pipeline. The skulls were designed to work both as standalone scattered props and in clustered arrangements across the environment.'},
-      {t:'Voodoo Veve Alphas',b:'Produced a set of Voodoo veve symbol alphas used as decal textures throughout the environment — painted onto wood, rock, and fabric surfaces to add narrative depth and occult atmosphere without additional geometry cost.'},
+      {t:'Voodoo Veve Alphas',b:'Produced a set of Voodoo veve symbol alphas used as decal textures throughout the environment, painted onto wood, rock, and fabric surfaces to add narrative depth and occult atmosphere without additional geometry cost.'},
       {t:'Level Design & Blockout',b:'Collaborated with the team on the overall level design from initial blockout through to final composition, ensuring the environment read clearly at a distance and rewarded exploration with detail at close range.'},
     ],
     specs:{tris:'6,800 tris · 3,900 verts · Hero Boat Prop<span style="display:block;margin-top:.55rem">840 tris · 440 verts · Skull</span>',textures:'2K PBR · 4 maps (Albedo, Normal, ORM, Emissive) · Hero Boat Prop<span style="display:block;margin-top:.55rem">2K PBR · 4 maps (Albedo, Normal, ORM, Emissive) · Baked High to Low · Skull</span>'},

--- a/public/index.html
+++ b/public/index.html
@@ -213,7 +213,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .lp.nat{border-color:var(--acc);color:var(--acc)}
 .skgrid{display:grid;grid-template-columns:1fr 1fr}
 .ski{display:inline-flex;align-items:center;gap:.32rem;font-size:.58rem;letter-spacing:.05em;padding:.24rem .55rem;background:var(--surf2);border:1px solid var(--brd);color:var(--mut);font-family:var(--fm);border-radius:9999px}
-.ski img,.sw img{filter:brightness(0) invert(1)}
+.ski img,.sw img{filter:brightness(0) invert(1) opacity(.65)}
 
 /* ── HOME: work strip ── */
 .wstrip{padding:0 2.5rem 4rem;max-width:1280px;margin:0 auto}

--- a/public/wp-content/uploads/2026/10/photoshop.svg
+++ b/public/wp-content/uploads/2026/10/photoshop.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 240 234" style="enable-background:new 0 0 240 234;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#ffffff}
+	.st0{fill:none}
 	.st1{fill:#ffffff}
 </style>
 <g id="Layer_2_1_">


### PR DESCRIPTION
## What Giovanni Asked For
Make all software logos white across the site, and refine portfolio text for a more polished professional presentation.

## What Changed
- Added CSS filter rule to make all software logos white with slight transparency (.ski img, .sw img)
- Swapped Photoshop logo from color version to white version (photoshop.svg)
- Rewrote About section professional summary
- Refined project descriptions across multiple entries for conciseness
- Changed em-dashes to middle dots in work history job titles
- Minor layout tweak to recommendation cards (display:flex for consistent spacing)

## Files Modified
- public/index.html — CSS logo filter rule, text rewrites across About/Work/Projects sections, Photoshop logo swap (+48/-47 lines)

## How to Verify
1. Open the Vercel preview URL
2. Check Skills section — all software logos should be white/light gray
3. Open any project post — software tags in sidebar should have white logos
4. Read About section and project descriptions for updated text
5. Check recommendation cards layout is consistent

## Risk Level
Low — CSS filter for logos, text content updates. One minor layout tweak to recommendation cards.

## Notes for Jonny
- CSS filter uses brightness(0) invert(1) opacity(.65) — makes any logo white at 65% opacity
- This supersedes the individual inline filters from PR 64 (ZBrush, UE5, VRay) — those inline styles are now redundant
- photoshop-color.svg is now orphaned (could be cleaned up later)
- Text rewrites are substantial — review the copy changes in the diff
- The .rc display:flex change affects recommendation card vertical alignment