### PR TITLE
Add press review videos to TimeSplitters and Witch's Den posts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -387,6 +387,14 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .cred-mentor-badge{font-size:.58rem;letter-spacing:.18em;text-transform:uppercase;background:var(--acc2);color:#eeebe5;padding:.2rem .6rem;width:fit-content;font-weight:600;margin-bottom:.3rem;border-radius:9999px}
 @media(max-width:540px){.credgrid{grid-template-columns:repeat(2,1fr)}.credcard.mentor{flex-direction:column;text-align:center}.credcard.mentor img{width:72px;height:72px}}
 
+/* press / critic reviews */
+.critsec{margin-top:3.5rem;padding-top:3rem;border-top:1px solid var(--brd);position:relative;z-index:11}
+.crittit{font-family:var(--fd);font-size:1.6rem;letter-spacing:.06em;margin-bottom:.5rem}
+.critsub{font-size:.72rem;color:var(--mut);margin-bottom:2rem;line-height:1.7;max-width:60ch}
+.critgrid{display:grid;grid-template-columns:repeat(2,1fr);gap:1.2rem}
+.critgrid.single{grid-template-columns:1fr;max-width:820px}
+@media(max-width:900px){.critgrid{grid-template-columns:1fr}}
+
 .relsec{margin-top:4.5rem;padding-top:2.5rem;border-top:1px solid var(--brd);position:relative;z-index:11}
 .reltit{font-size:.62rem;letter-spacing:.2em;text-transform:uppercase;color:var(--mut);font-weight:600;margin-bottom:1.6rem}
 .relgrid{display:grid;grid-template-columns:repeat(3,1fr);gap:3px;margin:0 -2.5rem}
@@ -1688,6 +1696,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
     <div class="gal" id="pgal"></div>
     <div class="bdsec" id="pbd"></div>
     <div class="credsec" id="pcredits" style="display:none"></div>
+    <div class="critsec" id="pcrit" style="display:none"></div>
     <div class="relsec">
       <div class="reltit">More Projects</div>
       <div class="relgrid" id="prel"></div>
@@ -2590,6 +2599,37 @@ function showPost(id){
   } else {
     credsec.style.display='none';
     credsec.innerHTML='';
+  }
+
+  // press / critic reviews
+  const critsec=document.getElementById('pcrit');
+  const ytCard=(ytid,label)=>`<div class="gi yt-embed">
+        <div class="yt-facade" onclick="ytPlay(this,'${ytid}')">
+          <img src="https://i.ytimg.com/vi/${ytid}/maxresdefault.jpg" onerror="this.src='https://i.ytimg.com/vi/${ytid}/hqdefault.jpg'" alt="${label}" loading="lazy" decoding="async">
+          <div class="yt-play"><svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3"/></svg></div>
+          <div class="yt-label">${label}</div>
+        </div>
+      </div>`;
+  if(p.cat==='ts'){
+    const vids=[
+      {ytid:'rXE7ijtr_0k',label:'TimeSplitters: Rewind — Press Coverage'},
+      {ytid:'uyryuA9rlaI',label:'TimeSplitters: Rewind — Press Coverage'},
+      {ytid:'gTZFOccomn8',label:'TimeSplitters: Rewind — Press Coverage'},
+      {ytid:'IKdCsCBTg6w',label:'TimeSplitters: Rewind — Press Coverage'},
+    ];
+    critsec.innerHTML=`
+      <div class="crittit">What Critics Are Saying</div>
+      <div class="critsub">Press and community coverage of TimeSplitters: Rewind from across the gaming world.</div>
+      <div class="critgrid">${vids.map(v=>ytCard(v.ytid,v.label)).join('')}</div>`;
+    critsec.style.display='block';
+  } else if(id==='witchden'){
+    critsec.innerHTML=`
+      <div class="crittit">Witch's Den Challenge — Live Review by Industry Professionals</div>
+      <div class="critgrid single">${ytCard('HZmUv9n60KI',"Witch's Den Challenge — Live Industry Review")}</div>`;
+    critsec.style.display='block';
+  } else {
+    critsec.style.display='none';
+    critsec.innerHTML='';
   }
 
   // related


### PR DESCRIPTION
## What Giovanni Asked For
Giovanni sent five YouTube links — four press/coverage videos he wants under every TimeSplitters: Rewind post, and one industry-review video for the Beyond Extent Witch's Den post. He asked for them to sit at the very bottom of each post (just before "More Projects") with a professional intro line.

## What Changed
- New "What Critics Are Saying" section on every TimeSplitters post (turret, spaceship, helicopter, impersonator, airplane, carousel, crane, bulletproof, cryogen, shoal). Embeds the four YouTube videos in a 2-column grid (single column on mobile).
- New "Witch's Den Challenge — Live Review by Industry Professionals" section on the Witch's Den post with the single review video.
- Section is positioned between Team Credits and More Projects so it reads as the closing piece of the post.
- YouTube embeds use the existing `yt-facade` click-to-play pattern (no autoload — keeps page light).
- Section only renders when the post matches (`cat==='ts'` or `id==='witchden'`); hidden everywhere else.

## Files Modified
- `public/index.html` — added `.critsec` styles, `#pcrit` container in the post template, and rendering logic in `showPost()`.

## How to Verify
1. Open the Vercel preview URL.
2. Open any TimeSplitters post (e.g. Turret, Carousel) → scroll past the Production Breakdown → "What Critics Are Saying" with 4 video thumbs should appear before "More Projects".
3. Open the Witch's Den post → scroll past Team Credits → single Witch's Den review video should appear before "More Projects".
4. Click any video thumb — facade swaps to a real YouTube embed and starts playing.
5. Open a non-TS / non-Witch's Den post (e.g. anything from Beyond Extent other than Witch's Den) → no critic section.
6. Resize to mobile → grid collapses to a single column.

## Risk Level
Low — additive change, isolated to the post template. Reuses existing `yt-facade` styling. Nothing else on the site touches `#pcrit` / `.critsec`.

## Notes for Jonny
- All four TimeSplitters videos use a generic label ("TimeSplitters: Rewind — Press Coverage") since Giovanni didn't specify per-video titles. Easy to swap individual labels later if he wants the publication name on each.
- Heading copy is "What Critics Are Saying" — Giovanni said "or something like that sounds professional", so this can be retitled trivially.
- No data field on the POSTS objects; the video lists are inline in `showPost()` since they're shared across all 10 TS posts. If we ever want per-post overrides, we can move it onto the POSTS object.

---
_Generated by [Claude Code](https://claude.ai/code/session_015hefq7Hc5Er3ENoZCVD2SM)_