### PR TITLE
Hide old work from default "All" filter view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2323,7 +2323,7 @@ function renderGrid(filter){
   const grid=document.getElementById('pgrid');
   grid.innerHTML='';
   const matches=(p)=>{
-    if(filter==='all')return true;
+    if(filter==='all')return p.cat==='beyond';
     if(filter==='oldwork')return p.cat==='ts'||p.cat==='cgi'||p.cat==='personal';
     return p.cat===filter;
   };


### PR DESCRIPTION
## What Giovanni Asked For
Old work shouldn't show up under the "All" filter — only Beyond Extent (his hero pieces) should be visible by default. Old work stays accessible behind the "Old Work" tab.

## What Changed
- `renderGrid` "All" filter now matches `p.cat==='beyond'` instead of returning every post. Result: landing on the portfolio shows only Witch's Den (and future Beyond Extent additions). Clicking "Old Work" still surfaces TS/CGI/Personal cards.

## Files Modified
- `public/index.html` — one-line change in `renderGrid`'s `matches()` function.

## How to Verify
1. Open Vercel preview.
2. Click View Portfolio. "All" tab is selected by default — confirm only Witch's Den shows (currently the only Beyond Extent post).
3. Click "Old Work" — confirm TS/CGI/Personal cards appear, all darkened.
4. Click "Beyond Extent" — same as "All" right now (just Witch's Den).

## Risk Level
Low — single-line filter logic change.

## Notes for Jonny
- The "All" tab is now functionally the same as "Beyond Extent" until Gio adds Kingdom Below or other Beyond Extent posts. Worth a future tweak: rename "All" to "Featured" or just remove it, since "All" is misleading when it filters to one category. Didn't do that here because Gio didn't ask for a rename — flag for him next time.

https://claude.ai/code/session_01Ry1hytzJosK5jwaZFzUZaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry1hytzJosK5jwaZFzUZaJ)_