### PR TITLE
Fix TS reel video freezing when not yet buffered at slide change

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1809,6 +1809,13 @@ window.gts=gts; window.ns=ns; window.ps=ps;
 at=setTimeout(()=>gts(1),7000);
 // explicitly play slide 0 video — HTML autoplay is unreliable on mobile
 (function(){const v=document.querySelectorAll('.slide-video')[0];if(v)v.play&&v.play().catch(()=>{});})();
+// retry play() once a video buffers enough — handles the case where gts() is
+// called before a large video has loaded (TS reel = 9MB, can miss the 7s window)
+document.querySelectorAll('.rslide').forEach((slide,i)=>{
+  const v=slide.querySelector('.slide-video');
+  if(!v)return;
+  v.addEventListener('canplay',()=>{if(cs===i)v.play&&v.play().catch(()=>{});});
+});
 // on first touch, unblock all slide videos so auto-advance plays them cleanly
 document.addEventListener('touchstart',function unlock(){
   document.querySelectorAll('.slide-video').forEach(v=>{


### PR DESCRIPTION
## What Giovanni Asked For
TS video in the showreel still stuck after the previous fix — just on a different frame.

## Root Cause
The TS file (`ts-rewind-2k-v3.mp4`) is 9.3MB; Witch's Den is 2MB. When the reel auto-advances at 7s/14s, the TS video often hasn't buffered enough data to play. `play()` returns a rejected Promise, the existing `.catch(()=>{})` silently swallows it, and the video freezes on whatever frame was decoded.

The previous fix (the `.rslide` index alignment) was correct and necessary — but on top of that, the play retry logic was always missing for slow-loading videos.

## What Changed
Added a `canplay` event listener per `.slide-video`. When the browser has buffered enough to play, the listener checks if that slide is currently active (`cs===i`) and calls `play()`. Once playback starts, the existing logic handles the rest.

## Files Modified
- `public/index.html` — 7-line addition right after the existing initial play() block.

## How to Verify
1. Open Vercel preview.
2. Wait through the auto-advance: Witch's Den → Kingdom Below → TimeSplitters. TS should now reliably start playing within ~1s of the slide becoming active, even on a fresh page load.
3. Click the TS dot directly right after page load — should play once buffered.
4. Same for clicking back to Witch's Den; both videos should play smoothly.

## Risk Level
Low — additive event listener, no change to existing playback logic.

## Notes for Jonny
- I considered transcoding the TS reel smaller, but a 9MB file is fine for desktop and reasonable for mobile; the playback logic just needs to handle the case where it's not buffered yet. The `canplay` retry is the right primitive here.
- If you ever want belt-and-suspenders, we could also call `v.load()` proactively on slide change minus 1, but I don't think it's necessary.

https://claude.ai/code/session_01Ry1hytzJosK5jwaZFzUZaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry1hytzJosK5jwaZFzUZaJ)_