### PR TITLE
Remove redundant Beyond Extent filter pill

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1398,7 +1398,6 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
     <div><h1>PORTFOLIO</h1><p>Props · Vehicles · Characters · Environments</p></div>
     <div class="pfilt">
       <button class="fb on" onclick="fc(this,'all')">All</button>
-      <button class="fb fb-beyond" onclick="fc(this,'beyond')">Beyond Extent</button>
       <button class="fb fb-old" onclick="fc(this,'oldwork')">Old Work</button>
     </div>
   </div>


### PR DESCRIPTION
## What Giovanni Asked For
Remove the "Beyond Extent" filter pill — just keep "All" and "Old Work".

## What Changed
- Dropped the `<button class="fb fb-beyond">` from the portfolio filter row.

## Files Modified
- `public/index.html` — one-line removal.

## How to Verify
1. Open Vercel preview, click View Portfolio.
2. Filter row should show only `All · Old Work`.
3. "All" shows Beyond Extent posts (Witch's Den). "Old Work" shows TS/CGI/Personal (darkened).

## Risk Level
Low — UI-only change, no logic touched.

## Notes for Jonny
The `.fb-beyond` CSS rules and the `'beyond'` branch in `renderGrid`'s `matches()` are now unreachable from the UI, but I left them in. If we ever want to bring back a Beyond Extent filter, it's still wired up. Easy cleanup later if you'd rather strip them.

https://claude.ai/code/session_01Ry1hytzJosK5jwaZFzUZaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry1hytzJosK5jwaZFzUZaJ)_