### PR TITLE
Add Kingdom Below video to hero carousel slide 2

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1076,14 +1076,16 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         </div>
       </div>
 
-      <!-- Slide 2: Kingdom Below — Coming Soon -->
+      <!-- Slide 2: Kingdom Below — direct MP4 from giovannilauffer.com -->
       <div class="rslide">
-        <div class="vfb fb3">KINGDOM BELOW</div>
+        <video class="slide-video sv-kingdom" autoplay muted loop playsinline preload="auto">
+          <source src="/wp-content/uploads/2026/05/kingdom-below-2k.mp4" type="video/mp4">
+        </video>
         <div class="rov"></div><div class="rob"></div>
         <div class="slide-info">
           <div class="si-tag">Beyond Extent Challenge</div>
           <div class="si-title">Kingdom Below</div>
-          <div class="si-sub">Environment Art · Coming Soon</div>
+          <div class="si-sub">Environment Art · Beyond Extent</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Replaced the Kingdom Below "Coming Soon" placeholder on hero slide 2 with an optimized clip from `NewLevelSequence.mp4`.
- Re-encoded the 2560×1440, 22s source (55.8MB / 20Mbps) to H.264 CRF 26, preset slow, audio stripped, `+faststart` — **landed at 11MB / 4.3Mbps**, matching the existing hero-video pipeline (Witches Den / TS).
- Updated the slide sub from "Environment Art · Coming Soon" → "Environment Art · Beyond Extent" to match the Witches Den slide convention now that the work is real.

## Files
- `public/index.html` — swapped the `vfb fb3` placeholder block for a `<video class="slide-video sv-kingdom">` element (same pattern as slides 1 and 3). No CSS or JS changes — the existing slide-video discovery in the carousel JS picks it up automatically.
- `public/wp-content/uploads/2026/05/kingdom-below-2k.mp4` — new 11MB asset.

## Verification
- Local serve + Chrome devtools confirmed: video fills the hero frame with `object-fit: cover`, **no black bars** top/bottom. Container is ~1.58 aspect, video is 16:9 — slight horizontal crop, no letterboxing.
- Autoplay + loop working; playback hits the carousel's existing play/pause-on-slide-change logic.

## Risk
Low — single-slide content swap, no CSS/JS changes, identical pattern to existing video slides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
