### PR TITLE
Crop letterbox on Kingdom Below clip, promote to hero slide 1

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1063,7 +1063,20 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 
     <div class="rslides" id="rslides">
 
-      <!-- Slide 1: Witch's Den — direct MP4 from giovannilauffer.com -->
+      <!-- Slide 1: Kingdom Below — direct MP4 from giovannilauffer.com -->
+      <div class="rslide">
+        <video class="slide-video sv-kingdom" autoplay muted loop playsinline preload="auto">
+          <source src="/wp-content/uploads/2026/05/kingdom-below-2k-v2.mp4" type="video/mp4">
+        </video>
+        <div class="rov"></div><div class="rob"></div>
+        <div class="slide-info">
+          <div class="si-tag">Beyond Extent Challenge</div>
+          <div class="si-title">Kingdom Below</div>
+          <div class="si-sub">Environment Art · Beyond Extent</div>
+        </div>
+      </div>
+
+      <!-- Slide 2: Witch's Den — direct MP4 from giovannilauffer.com -->
       <div class="rslide">
         <video class="slide-video sv-witchden" autoplay muted loop playsinline preload="auto" poster="/wp-content/uploads/2026/03/witch-den-thumbnail.webp">
           <source src="/wp-content/uploads/2025/12/WitchesDen-2k-1.mp4" type="video/mp4">
@@ -1072,19 +1085,6 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         <div class="slide-info">
           <div class="si-tag">Beyond Extent Challenge</div>
           <div class="si-title">Witch's Den</div>
-          <div class="si-sub">Environment Art · Beyond Extent</div>
-        </div>
-      </div>
-
-      <!-- Slide 2: Kingdom Below — direct MP4 from giovannilauffer.com -->
-      <div class="rslide">
-        <video class="slide-video sv-kingdom" autoplay muted loop playsinline preload="auto">
-          <source src="/wp-content/uploads/2026/05/kingdom-below-2k.mp4" type="video/mp4">
-        </video>
-        <div class="rov"></div><div class="rob"></div>
-        <div class="slide-info">
-          <div class="si-tag">Beyond Extent Challenge</div>
-          <div class="si-title">Kingdom Below</div>
           <div class="si-sub">Environment Art · Beyond Extent</div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Two fixes on top of PR #78:

1. **Cropped baked-in letterbox.** The source `NewLevelSequence.mp4` was a 2.39:1 cinematic render with ~184px black bars baked into the top and bottom of the 1440p frame — those bars were what showed inside the hero, not browser letterboxing. Re-encoded with `crop=2560:1072:0:184` to strip them at the pixel level. With `object-fit: cover`, the now-wider 2.39:1 content naturally fills the hero vertically and crops more on the sides — i.e. it zooms in.
2. **Promoted to slide 1.** Kingdom Below is now hero slide 1; Witch's Den moves to slide 2. Slides 3 (TimeSplitters) and 4 (Underground Subway) unchanged.

## Files
- `public/index.html` — swapped slide 1 and slide 2 blocks; updated Kingdom Below `src` to the new `-v2` filename.
- `public/wp-content/uploads/2026/05/kingdom-below-2k-v2.mp4` — new 11MB asset, 2560×1072 H.264 CRF 26, audio stripped, faststart.
- `public/wp-content/uploads/2026/05/kingdom-below-2k.mp4` — **removed** (letterboxed version). New filename also acts as a cache buster.

## Verification
- ffprobe confirms 2560×1072 (was 2560×1440); pixel scan of a midpoint frame shows top_bar=1, bot_bar=0 (true black).
- Local browser test: video aspect reports 2.388 in the DOM, slide 1 renders edge-to-edge with no visible black bars, KINGDOM BELOW caption is correctly positioned.

## Risk
Low — same hero-video pattern as before, just a cleaner source. Old asset is removed but the new filename means any browser still holding the old URL will simply 404 rather than serve broken content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
