### PR TITLE
Portfolio polish v2: perf, recs/edu/awards order, role copy, transition smoothing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -268,12 +268,16 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 /* ── HOME: recs ── */
 .rstrip{padding:0 2.5rem 5rem}
 .recgrid{display:grid;grid-template-columns:1fr 1fr;gap:2px;overflow:hidden;border-radius:10px}
+/* Top corners are always on the first row */
 .recgrid .rc:first-child{border-top-left-radius:10px}
 .recgrid .rc:nth-child(2){border-top-right-radius:10px}
-.recgrid .rc:nth-last-child(2){border-bottom-left-radius:10px}
-.recgrid .rc:last-child{border-bottom-right-radius:10px}
-/* odd count: last card spans both columns so the grid doesn't leave a half-empty row */
-.recgrid .rc:last-child:nth-child(odd){grid-column:1/-1;border-bottom-left-radius:10px}
+/* Even count (no .rc:last-child:nth-child(odd) present) — last two cards form
+   the bottom row and each rounds its outer corner. */
+.recgrid:not(:has(.rc:last-child:nth-child(odd))) .rc:nth-last-child(2){border-bottom-left-radius:10px}
+.recgrid:not(:has(.rc:last-child:nth-child(odd))) .rc:last-child{border-bottom-right-radius:10px}
+/* Odd count — final card is alone on the bottom-left, right cell stays empty.
+   Round the BL of the final card and leave inner corners square. */
+.recgrid:has(.rc:last-child:nth-child(odd)) .rc:last-child{border-bottom-left-radius:10px}
 /* rec cards are now <a> tags — reset link styles */
 .rc{background:var(--surf);padding:1.8rem;display:flex;flex-direction:column;justify-content:space-between;text-decoration:none;color:inherit;transition:background .2s,box-shadow .2s}
 .rc:hover{background:#1c1c1f;box-shadow:inset 0 0 0 1px var(--acc)}
@@ -414,7 +418,10 @@ nav{position:fixed;top:0;left:0;right:0;z-index:300;display:flex;align-items:cen
 .credname{font-size:.84rem;font-weight:500;color:var(--txt);line-height:1.3}
 .credrole{font-size:.65rem;letter-spacing:.06em;color:var(--acc);font-weight:500;margin-top:.1rem;line-height:1.4}
 .credexp{font-size:.63rem;color:var(--mut);line-height:1.5;margin-top:.15rem}
-.credli{display:inline-flex;align-items:center;gap:.3rem;font-size:.62rem;letter-spacing:.08em;text-transform:uppercase;color:var(--acc2);margin-top:.4rem;font-weight:500}
+/* margin-top:auto pushes the LinkedIn label to the bottom of the flex column
+   so it sits on a consistent baseline across cards regardless of how many
+   lines the role text takes — fixes the dancing-baseline on Kingdom team. */
+.credli{display:inline-flex;align-items:center;gap:.3rem;font-size:.62rem;letter-spacing:.08em;text-transform:uppercase;color:var(--acc2);margin-top:auto;padding-top:.4rem;font-weight:500}
 .credcard.mentor{grid-column:1/-1;flex-direction:row;text-align:left;gap:1.2rem;border-color:var(--acc2);padding:1.6rem}
 .credcard.mentor img{width:80px;height:80px;flex-shrink:0}
 .cred-mentor-info{display:flex;flex-direction:column;gap:.2rem}
@@ -1150,7 +1157,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
       <div class="avail-hero ai"><span class="avail-dot"></span>Available for Work</div>
       <div class="htag ai">3D Prop & Environment Artist · Ede, Netherlands</div>
       <h1 class="hname ai d1"><span class="l1"><span class="l1-o">GIOVANNI</span><span class="l1-sun" aria-hidden="true">GIOVANNI</span><span class="l1-o-orange" aria-hidden="true">GIOVANNI</span><span class="l1-f" aria-hidden="true">GIOVANNI</span></span><span class="l2">LAUFFER</span></h1>
-      <p class="hrole ai d2">Props · Characters · Vehicles · Environments<br>Maya · ZBrush · Substance · UE5 · 3DS Max · VRay</p>
+      <p class="hrole ai d2">Environment Art<br>Maya · ZBrush · Substance · UE5 · 3DS Max · VRay</p>
       <div class="hstats ai d3">
         <div><div class="sn">5+</div><div class="sl">Years Exp</div></div>
         <div><div class="sn">2</div><div class="sl">Studios</div></div>
@@ -1309,13 +1316,14 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
     <div class="wsec" style="margin-top:3rem">Education</div>
     <div class="witems witems-r">
 
-      <a class="wi wi-link" href="https://www.saxion.edu" target="_blank" rel="noopener noreferrer">
-        <div class="wlogo"><img src="/wp-content/uploads/2024/07/lg_saxion_rgb.webp" alt="Saxion" loading="lazy" decoding="async"></div>
+      <!-- Reverse-chronological: Kingdom Below (Apr 2026) · Witch's Den (Nov 2025) · Saxion (2016-20) · ISC (2007-13) -->
+      <a class="wi wi-link" href="https://www.beyondextent.com/" target="_blank" rel="noopener noreferrer">
+        <div class="wlogo"><img src="/wp-content/uploads/2025/11/BeyondExtent_Logo_White_Monotone-150x150.webp" alt="Beyond Extent" loading="lazy" decoding="async"></div>
         <div class="wdiv"></div>
         <div class="winfo">
-          <div class="wt">Saxion University of Applied Sciences <span class="wlink">↗</span></div>
-          <div class="wd">2016 – 2020 &middot; Enschede, Netherlands</div>
-          <div class="wdsc"><strong style="color:var(--txt);font-weight:500">Bachelor Degree</strong><br>Creative Media and Game Technologies</div>
+          <div class="wt">Beyond Extent <span class="wlink">↗</span></div>
+          <div class="wd">Apr 2026 &middot; Remote · Online Community</div>
+          <div class="wdsc"><strong style="color:var(--txt);font-weight:500">Kingdom Below Challenge</strong><br>Team environment art challenge</div>
         </div>
       </a>
 
@@ -1329,6 +1337,16 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         </div>
       </a>
 
+      <a class="wi wi-link" href="https://www.saxion.edu" target="_blank" rel="noopener noreferrer">
+        <div class="wlogo"><img src="/wp-content/uploads/2024/07/lg_saxion_rgb.webp" alt="Saxion" loading="lazy" decoding="async"></div>
+        <div class="wdiv"></div>
+        <div class="winfo">
+          <div class="wt">Saxion University of Applied Sciences <span class="wlink">↗</span></div>
+          <div class="wd">2016 – 2020 &middot; Enschede, Netherlands</div>
+          <div class="wdsc"><strong style="color:var(--txt);font-weight:500">Bachelor Degree</strong><br>Creative Media and Game Technologies</div>
+        </div>
+      </a>
+
       <a class="wi wi-link" href="https://www.isc.cw/" target="_blank" rel="noopener noreferrer">
         <div class="wlogo"><img src="/wp-content/uploads/2024/07/ISC.webp" alt="ISC" loading="lazy" decoding="async" style="max-height:48px;max-width:72px"></div>
         <div class="wdiv"></div>
@@ -1339,20 +1357,20 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
         </div>
       </a>
 
-      <a class="wi wi-link" href="https://www.beyondextent.com/" target="_blank" rel="noopener noreferrer">
-        <div class="wlogo"><img src="/wp-content/uploads/2025/11/BeyondExtent_Logo_White_Monotone-150x150.webp" alt="Beyond Extent" loading="lazy" decoding="async"></div>
-        <div class="wdiv"></div>
-        <div class="winfo">
-          <div class="wt">Beyond Extent <span class="wlink">↗</span></div>
-          <div class="wd">Apr 2026 &middot; Remote · Online Community</div>
-          <div class="wdsc"><strong style="color:var(--txt);font-weight:500">Kingdom Below Challenge</strong><br>Team environment art challenge</div>
-        </div>
-      </a>
-
     </div>
 
     <div class="wsec" style="margin-top:3rem">Awards</div>
     <div class="witems witems-r">
+      <!-- Awards stacked recent-first, both span full width like the existing layout -->
+      <a class="wi wi-link" href="#" onclick="showPost('kingdom');return false;" style="grid-column:1/-1">
+        <div class="wlogo" style="width:72px;flex-shrink:0;display:flex;align-items:center;justify-content:center"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 42 42" style="fill:#999;stroke:none"><path d="M39,21c0-2.967-2.167-5.431-5-5.91V6.675c0-2.026-1.648-3.675-3.675-3.675H11.675c-2.026,0-3.675,1.649-3.675,3.675v28.649c0,2.026,1.648,3.675,3.675,3.675h18.65c2.026,0,3.675-1.649,3.675-3.675v-2.456l1.445.964c.167.112.36.168.555.168.162,0,.324-.039.472-.118.325-.174.528-.513.528-.882v-7.54c1.224-1.099,2-2.688,2-4.46ZM30.325,37H11.675c-.924,0-1.675-.751-1.675-1.675V6.675c0-.924.751-1.675,1.675-1.675h18.65c.924,0,1.675.751,1.675,1.675v8.415c-2.833.478-5,2.942-5,5.91,0,1.771.776,3.36,2,4.46v7.54c0,.369.203.708.528.882.324.173.72.154,1.026-.05l1.445-.964v2.456c0,.924-.751,1.675-1.675,1.675ZM35,31.131l-1.445-.963c-.336-.224-.773-.224-1.109,0l-1.445.963v-4.481c.627.223,1.298.35,2,.35s1.373-.128,2-.35v4.481ZM33,25c-2.206,0-4-1.794-4-4s1.794-4,4-4,4,1.794,4,4-1.794,4-4,4Z"/><path d="M14.643,14h12.715c.905,0,1.643-.737,1.643-1.643v-2.715c0-.906-.737-1.643-1.643-1.643h-12.715c-.905,0-1.643.737-1.643,1.643v2.715c0,.906.737,1.643,1.643,1.643ZM15,10h12v2h-12v-2Z"/><path d="M24,17h-10c-.553,0-1,.448-1,1s.447,1,1,1h10c.553,0,1-.448,1-1s-.447-1-1-1Z"/><path d="M24,22h-10c-.553,0-1,.448-1,1s.447,1,1,1h10c.553,0,1-.448,1-1s-.447-1-1-1Z"/><path d="M24,27h-10c-.553,0-1,.448-1,1s.447,1,1,1h10c.553,0,1-.448,1-1s-.447-1-1-1Z"/></svg></div>
+        <div class="wdiv"></div>
+        <div class="winfo">
+          <div class="wt">Kingdom Below · Beyond Extent Team Challenge <span class="wlink">↗</span></div>
+          <div class="wd">2nd Place · AAA Judges' Choice · Apr 2026</div>
+          <div class="wdsc">Team challenge by Beyond Extent. Team 5 (CTRL ALT DESCENT) took 2nd place, voted by industry judges from Singularity 6, Crytek, and PUBG Amsterdam.</div>
+        </div>
+      </a>
       <a class="wi wi-link" href="#" onclick="showPost('grabaduck');return false;" style="grid-column:1/-1">
         <div class="wlogo" style="width:72px;flex-shrink:0;display:flex;align-items:center;justify-content:center"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 42 42" style="fill:#999;stroke:none"><path d="M39,21c0-2.967-2.167-5.431-5-5.91V6.675c0-2.026-1.648-3.675-3.675-3.675H11.675c-2.026,0-3.675,1.649-3.675,3.675v28.649c0,2.026,1.648,3.675,3.675,3.675h18.65c2.026,0,3.675-1.649,3.675-3.675v-2.456l1.445.964c.167.112.36.168.555.168.162,0,.324-.039.472-.118.325-.174.528-.513.528-.882v-7.54c1.224-1.099,2-2.688,2-4.46ZM30.325,37H11.675c-.924,0-1.675-.751-1.675-1.675V6.675c0-.924.751-1.675,1.675-1.675h18.65c.924,0,1.675.751,1.675,1.675v8.415c-2.833.478-5,2.942-5,5.91,0,1.771.776,3.36,2,4.46v7.54c0,.369.203.708.528.882.324.173.72.154,1.026-.05l1.445-.964v2.456c0,.924-.751,1.675-1.675,1.675ZM35,31.131l-1.445-.963c-.336-.224-.773-.224-1.109,0l-1.445.963v-4.481c.627.223,1.298.35,2,.35s1.373-.128,2-.35v4.481ZM33,25c-2.206,0-4-1.794-4-4s1.794-4,4-4,4,1.794,4,4-1.794,4-4,4Z"/><path d="M14.643,14h12.715c.905,0,1.643-.737,1.643-1.643v-2.715c0-.906-.737-1.643-1.643-1.643h-12.715c-.905,0-1.643.737-1.643,1.643v2.715c0,.906.737,1.643,1.643,1.643ZM15,10h12v2h-12v-2Z"/><path d="M24,17h-10c-.553,0-1,.448-1,1s.447,1,1,1h10c.553,0,1-.448,1-1s-.447-1-1-1Z"/><path d="M24,22h-10c-.553,0-1,.448-1,1s.447,1,1,1h10c.553,0,1-.448,1-1s-.447-1-1-1Z"/><path d="M24,27h-10c-.553,0-1,.448-1,1s.447,1,1,1h10c.553,0,1-.448,1-1s-.447-1-1-1Z"/></svg></div>
         <div class="wdiv"></div>
@@ -1368,18 +1386,9 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 
   <!-- Recommendations -->
   <div class="rstrip reveal">
-    <div class="wsec">Industry Recommendations</div>
+    <div class="wsec">Recommendations</div>
+    <!-- Order: gaming/AAA seniors first, then recent peer (Andres), CGI/Lukkien (Rutgher) last -->
     <div class="recgrid">
-      <a class="rc" href="https://www.linkedin.com/in/andres-o-897bb7163/" target="_blank" rel="noopener noreferrer">
-        <div class="rq">"I want to give a special shout-out to Giovanni for his incredible presence on my team. Beyond his technical skill, Giovanni is exceptionally mindful of those around him. He consistently boosted our morale with his motivation and kind words, keeping the energy positive even during difficult stretches. Furthermore, his ability to take critique and iterate with a growth mindset made our collaboration seamless. He is a true asset to any creative team."</div>
-        <div class="rp">
-          <img src="/wp-content/uploads/2026/05/team/andres-olave.webp" alt="Andres Olave" loading="lazy" decoding="async">
-          <div>
-            <div class="rn">Andres Olave <span class="rlink">↗</span></div>
-            <div class="rr">3D Artist · Beyond Extent Kingdom Below Team<br>May 2026 · Worked with Giovanni on the same team</div>
-          </div>
-        </div>
-      </a>
       <a class="rc" href="https://cameronwgames.com/" target="_blank" rel="noopener noreferrer">
         <div class="rq">"Prior to beginning my time at Rockstar, I acted as producer for Giovanni, providing him with ongoing tasks and critique. Giovanni has a striking mindset of 'what's next' and was always extremely enthusiastic in providing high quality assets for TimeSplitters Rewind with a strong diligence not often found among other prop and environment artists. He would always run with critique and go above and beyond the expectations of the team to the point where we put him on the highest quality hero assets, trusting him with some of the most commonly viewed props throughout the game. I highly recommend Giovanni from my time managing him and think he'd do great in any studio!"</div>
         <div class="rp">
@@ -1407,6 +1416,16 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
           <div>
             <div class="rn">Samuel Freeman <span class="rlink">↗</span></div>
             <div class="rr">Character Artist, Splash Damage<br>Formerly Bulkhead · Cinder Interactive</div>
+          </div>
+        </div>
+      </a>
+      <a class="rc" href="https://www.linkedin.com/in/andres-o-897bb7163/" target="_blank" rel="noopener noreferrer">
+        <div class="rq">"I want to give a special shout-out to Giovanni for his incredible presence on my team. Beyond his technical skill, Giovanni is exceptionally mindful of those around him. He consistently boosted our morale with his motivation and kind words, keeping the energy positive even during difficult stretches. Furthermore, his ability to take critique and iterate with a growth mindset made our collaboration seamless. He is a true asset to any creative team."</div>
+        <div class="rp">
+          <img src="/wp-content/uploads/2026/05/team/andres-olave.webp" alt="Andres Olave" loading="lazy" decoding="async">
+          <div>
+            <div class="rn">Andres Olave <span class="rlink">↗</span></div>
+            <div class="rr">3D Artist · Beyond Extent Kingdom Below Team<br>May 2026 · Worked with Giovanni on the same team</div>
           </div>
         </div>
       </a>
@@ -1452,7 +1471,7 @@ a:focus-visible,button:focus-visible,[role="button"]:focus-visible,.pcard:focus-
 ══════════════════════════════════════ -->
 <div id="portfolio">
   <div class="phead">
-    <div><h1>PORTFOLIO</h1><p>Props · Vehicles · Characters · Environments</p></div>
+    <div><h1>PORTFOLIO</h1><p>Environment Art</p></div>
     <div class="pfilt">
       <button class="fb on" onclick="fc(this,'all')">All</button>
       <button class="fb fb-old" onclick="fc(this,'oldwork')">Old Work</button>
@@ -1842,6 +1861,17 @@ function addHov(sel){document.querySelectorAll(sel).forEach(el=>{
 addHov('a,button,.pcard,.gi,.relcard,.rbtn,.fb,.rc');
 }
 
+// ── small global helper: pause every <video> inside the given selectors.
+// Used when navigating away from a page so background videos stop chewing CPU. ──
+function pauseAllVideosIn(sel){
+  document.querySelectorAll(sel+' video').forEach(v=>{ try{v.pause();}catch(e){} });
+}
+window.pauseAllVideosIn=pauseAllVideosIn;
+
+// Returns true when the home reel is actually being shown — avoids burning CPU
+// auto-advancing slides + retrying play() on hidden videos.
+function homeVisible(){return !document.getElementById('home').classList.contains('hidden');}
+
 // ── reel (3 slides) — also pause/play videos on slide change ──
 let cs=0; const T=4; let at;
 function gts(n){
@@ -1849,14 +1879,21 @@ function gts(n){
   document.getElementById('rslides').style.transform=`translateX(-${cs*100}%)`;
   document.querySelectorAll('.rdot').forEach((d,i)=>d.classList.toggle('on',i===cs));
   document.getElementById('rtim').textContent=`0${cs+1} / 0${T}`;
-  // play active slide video, pause others
+  // play active slide video, pause others — but only when the home reel is
+  // actually visible, otherwise the user is on a different page and there is
+  // nothing to render.
+  const showing=homeVisible();
   document.querySelectorAll('.rslide').forEach((slide,i)=>{
     const v=slide.querySelector('.slide-video');
     if(!v)return;
-    if(i===cs){if(v.querySelector('source')?.getAttribute('src')!=='/ts-rewind-2k-v3.mp4')v.currentTime=0;v.play&&v.play().catch(()=>{});}
+    if(showing && i===cs){if(v.querySelector('source')?.getAttribute('src')!=='/ts-rewind-2k-v3.mp4')v.currentTime=0;v.play&&v.play().catch(()=>{});}
     else{v.pause && v.pause();}
   });
-  clearTimeout(at); at=setTimeout(()=>gts(cs+1),7000);
+  clearTimeout(at);
+  // Only schedule the next auto-advance when home is visible — otherwise the
+  // carousel keeps ticking + calling play() on hidden videos which causes the
+  // desktop reel to feel laggy after navigating around the site.
+  if(showing) at=setTimeout(()=>gts(cs+1),7000);
 }
 function ns(){gts(cs+1);}
 function ps(){gts(cs-1);}
@@ -2496,9 +2533,15 @@ function showHome(){
   document.getElementById('about').classList.remove('on');
   document.getElementById('bnav').classList.remove('on');
   document.getElementById('hire').classList.remove('on');
+  // Resume the reel only after the home container is visible again — otherwise
+  // the play() call in gts() would still target a display:none video.
+  if(typeof gts==='function')gts(cs||0);
+  // Make sure any post-page or about-page videos stop while we sit on home.
+  pauseAllVideosIn('#post, #about');
   window.scrollTo(0,0);
 }
 function showAbout(){
+  pauseAllVideosIn('#home, #post');
   document.getElementById('home').classList.add('hidden');
   document.getElementById('portfolio').classList.remove('on');
   document.getElementById('post').classList.remove('on');
@@ -2556,6 +2599,8 @@ function showAbout(){
   }
 }
 function showPortfolio(){
+  // pause home + post videos so background decoding stops while user browses
+  pauseAllVideosIn('#home, #post');
   document.getElementById('home').classList.add('hidden');
   document.getElementById('portfolio').classList.add('on');
   document.getElementById('post').classList.remove('on');
@@ -2576,6 +2621,13 @@ function fc(btn,cat){
 
 function showPost(id){
   const p=POSTS[id];if(!p)return;
+  // Scroll to top FIRST so the user doesn't see the previous post's gallery
+  // thumbnails briefly swap before the page jumps — was causing a flicker when
+  // clicking More Projects cards from near the bottom of a post.
+  window.scrollTo(0,0);
+  // Pause anything that might be playing on the previous page so the swap is
+  // crisp (and we don't lag the new render with leftover decode work).
+  pauseAllVideosIn('#home, #post');
   document.getElementById('home').classList.add('hidden');
   document.getElementById('portfolio').classList.remove('on');
   document.getElementById('about').classList.remove('on');
@@ -2689,8 +2741,19 @@ function showPost(id){
   const has3d=p.images.some(i=>i.type==='sketchfab');
   document.querySelector('.galh').textContent=has3d?'3D Viewer & Images':'Images';
   document.getElementById('pgal').innerHTML=galHTML;
-  // explicitly play gallery videos — HTML autoplay is unreliable on mobile
-  document.querySelectorAll('#pgal video').forEach(v=>{v.play&&v.play().catch(()=>{});});
+  // Only play gallery videos when they're near the viewport. Kingdom Below has
+  // 9 videos in its gallery — playing all simultaneously on mobile causes the
+  // page to stutter while scrolling. The IntersectionObserver pauses videos
+  // that scroll out and resumes them when they come back in.
+  if(window._galIO){try{window._galIO.disconnect();}catch(e){}}
+  window._galIO=new IntersectionObserver(entries=>{
+    entries.forEach(e=>{
+      const v=e.target;
+      if(e.isIntersecting){v.play&&v.play().catch(()=>{});}
+      else{v.pause&&v.pause();}
+    });
+  },{rootMargin:'200px 0px'});
+  document.querySelectorAll('#pgal video').forEach(v=>{window._galIO.observe(v);});
 
   // breakdown
   document.getElementById('pbd').innerHTML=`
@@ -2780,6 +2843,10 @@ function showPost(id){
     critsec.innerHTML='';
   }
 
+  // pause the previous post's stale scroll position by jumping to top before the
+  // gallery videos start decoding — re-scroll here too in case any layout reflow
+  // changed scroll height.
+  window.scrollTo(0,0);
   // related — for new-work (Beyond Extent) posts, only show other new-work posts;
   // older categories still get a mixed slice so Old Work pages don't go empty.
   document.getElementById('prel').innerHTML=ORDER.filter(rid=>{
@@ -2862,12 +2929,21 @@ function toggleMusic(){
 window.toggleMusic=toggleMusic;
 
 // ── scroll progress bar + scroll-to-top ──
+// rAF-batched so we touch DOM at most once per frame even when the scroll
+// event fires 60-120 times per second on mobile — was contributing to scroll
+// stutter on long pages (Kingdom Below post in particular).
 const spbar=document.getElementById('spbar');
 const sttb=document.getElementById('sttb');
+let _spTick=false;
 window.addEventListener('scroll',()=>{
-  const pct=(window.scrollY/(document.documentElement.scrollHeight-window.innerHeight))*100;
-  if(spbar)spbar.style.width=pct+'%';
-  if(sttb)sttb.classList.toggle('on',window.scrollY>420);
+  if(_spTick)return;
+  _spTick=true;
+  requestAnimationFrame(()=>{
+    _spTick=false;
+    const pct=(window.scrollY/(document.documentElement.scrollHeight-window.innerHeight))*100;
+    if(spbar)spbar.style.width=pct+'%';
+    if(sttb)sttb.classList.toggle('on',window.scrollY>420);
+  });
 },{passive:true});
 
 // ── reveal on scroll ──

--- a/public/index.html
+++ b/public/index.html
@@ -1862,9 +1862,12 @@ addHov('a,button,.pcard,.gi,.relcard,.rbtn,.fb,.rc');
 }
 
 // ── small global helper: pause every <video> inside the given selectors.
-// Used when navigating away from a page so background videos stop chewing CPU. ──
+// Used when navigating away from a page so background videos stop chewing CPU.
+// Splits comma-separated selectors so we don't accidentally turn "#home, #post"
+// into "#home, #post video" (which would miss every video inside #home). ──
 function pauseAllVideosIn(sel){
-  document.querySelectorAll(sel+' video').forEach(v=>{ try{v.pause();}catch(e){} });
+  const compound=sel.split(',').map(s=>s.trim()+' video').join(',');
+  document.querySelectorAll(compound).forEach(v=>{ try{v.pause();}catch(e){} });
 }
 window.pauseAllVideosIn=pauseAllVideosIn;
 


### PR DESCRIPTION
## What Giovanni Asked For

12 things in one batch:

1. **Old Work filter still on top left** — already shipped a fix in the last PR; my measurements show the live CSS does have `align-self:flex-end + margin-left:auto` and the .pfilt sits at the right edge at mobile widths (x≈320 / right≈469 on a 500px viewport). My best read is that Gio was looking at a cached copy. This PR doesn't add another fix — preview will let him confirm.
2. **Mobile scroll stutter** — Kingdom Below post has 9 gallery videos all autoplaying. Mobile GPUs choke. Wrapped them in an IntersectionObserver so only videos within 200px of the viewport play.
3. **Desktop reel goes laggy after using the site** — the carousel was scheduling auto-advance + calling `play()` even when the home container was `display:none`, so 4 hidden hero videos and a 7s timer kept running in the background forever. Carousel now early-exits when home isn't visible.
4. **Samuel Freeman card's inner BL corner was rounded** — recgrid's corner rules assumed even card count. Replaced with `:has()`-based rules that branch on odd vs even card count: at 5 cards only the final card rounds its BL, internal corners stay 90°.
5. **"Industry Recommendations" → "Recommendations"**.
6. **Reorder recs**: Cameron, Willem, Samuel, Andres, Rutgher (Andres moved from first → fourth, right before Rutgher).
7. **Rutgher box too wide** — removed the `:last-child:nth-child(odd){grid-column:1/-1}` rule so the last card no longer spans both columns. Bottom row is now: Rutgher on the left, empty cell on the right.
8. **Education reverse-chronological**: Kingdom Below (Apr 2026) top-left → Witch's Den (Nov 2025) top-right → Saxion (2016-20) bottom-left → ISC (2007-13) bottom-right.
9. **Awards: add Kingdom Below 2nd Place on top, linking to the Kingdom Below post**. Card has the same award icon + spans full width like Grab a Duck. Click handler: `showPost('kingdom')`.
10. **Hero role + portfolio subtitle** simplified to "Environment Art" (was "Props · Characters · Vehicles · Environments" / "Props · Vehicles · Characters · Environments"). The software list under it stays on the hero.
11. **More Projects flicker** — `showPost()` now scrolls to top *first* and pauses the previous page's videos, so users no longer see the related rail's thumbnails flicker to the new post's data before the page jumps.
12. **Kingdom team LinkedIn labels dancing in height** — added `margin-top:auto` to `.credli` so the LinkedIn label is pushed to the bottom of every card's flex column. Cards in the same grid row already had equal height via CSS Grid's `stretch`, so the label baseline now lines up regardless of how many lines the role text wraps to.

## What Changed (files)

`public/index.html` — single file, 5 logical blocks of edits:

- **CSS**: recgrid `:has()` corner rules, `.credli{margin-top:auto;padding-top:.4rem}`.
- **HTML**: hero copy, portfolio subtitle copy, education re-ordered, awards now has 2 entries, recs reordered, "Industry Recommendations" → "Recommendations".
- **JS perf**: new `pauseAllVideosIn(sel)` helper, `homeVisible()` predicate, carousel `gts()` early-exits when home is hidden, `showHome/showPortfolio/showAbout/showPost` all call `pauseAllVideosIn`, gallery videos in `showPost` registered with an IntersectionObserver, scroll listener rAF-batched.
- **More Projects transition**: `window.scrollTo(0,0)` moved to the start of `showPost()` (also added at the end of the related-render section as a belt-and-braces no-op).

## How to Verify

1. **Hero**: role line under "GIOVANNI LAUFFER" now reads "Environment Art" (then the software list).
2. **Recommendations** (home, scroll down): heading is "Recommendations". Cards in order: Cameron, Willem, Samuel, Andres, Rutgher.
   - The bottom row is just Rutgher on the left + empty cell on the right.
   - Samuel's BL corner is square (no rounding).
   - Top corners of the section: rounded (Cameron TL, Willem TR). Bottom-left: rounded (Rutgher BL). Internal corners all 90°.
3. **Education**: 2×2 grid in order Kingdom Below → Witch's Den → Saxion → ISC.
4. **Awards**: 2 stacked full-width cards — Kingdom Below 2nd Place on top (click opens the Kingdom Below post), Grab a Duck below.
5. **Portfolio header**: subtitle reads "Environment Art".
6. **Filter button position**: on desktop, tablet, and phone, the All / Old Work buttons sit at the right of the PORTFOLIO header. Toggling the filter doesn't move them.
7. **More Projects flicker**: open any post, scroll to the bottom, click a related card. The page should jump to the top *first*, then render the new post — no thumbnail flicker.
8. **Kingdom team baseline**: open Kingdom Below post, scroll to Team Credits. Lea, Justin, Kirill, Andres — the orange "LinkedIn" labels are on the same y baseline across all 4 cards.
9. **Mobile stutter**: open Kingdom Below post on a phone (or DevTools mobile), scroll all the way down through the 9 gallery videos and back up. Should feel smooth — only the videos near your viewport are playing at any time.
10. **Desktop reel lag**: open home, click Portfolio, click into Kingdom Below, click around 2–3 More Projects cards, then click Home in the nav. The reel should still be responsive (not laggy) — it stops playing when home is hidden and only resumes when you navigate back.

## Risk Level

**Medium-low** — touches navigation flow and the carousel timer. The carousel `gts(cs||0)` resume call in `showHome()` is the highest-risk line: if `cs` were undefined we'd land on slide 0; I tested that path manually before pushing. Layout/CSS edits are isolated to recgrid and credli — they fall back gracefully if `:has()` isn't supported (modern Chrome/Safari/Firefox all support it).

## Notes for Jonny

- Filter regression #1 didn't need a code change — the prior fix already shipped and lives on prod. If Gio still sees it after a hard refresh on the new preview, that's where to dig.
- I considered changing the recgrid grid to `repeat(auto-fill, minmax(...))` instead of fixed `1fr 1fr` so future card counts auto-pack. Held off because the rounded-corner ruleset is calibrated for a 2-column layout. Easy to revisit later.
- Carousel still uses 4 slides hardcoded (`const T=4`). If Gio ever wants 5 slides we'll want to drive that from the slide count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
